### PR TITLE
Add files via upload

### DIFF
--- a/BL3_Crit_Manufacture.bl3hotfix
+++ b/BL3_Crit_Manufacture.bl3hotfix
@@ -1,0 +1,43 @@
+###
+### Name: Crit Manufacture
+### Version: 1.0.0
+### Author: Wayne-The-Brain-McClain
+### Categories: gameplay
+###
+
+
+
+
+### Crit changes
+
+# Dahl
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Dahl,DamageScale_36_150C89A04BB4FCF0061CAC86E39E1A39,0,,1.476
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Dahl,CritDamageScale_63_CD26C16D40CD2DDF676270956F04A694,0,,0.65
+
+# Jakobs
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Jakobs,DamageScale_36_150C89A04BB4FCF0061CAC86E39E1A39,0,,1.466
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Jakobs,CritDamageScale_63_CD26C16D40CD2DDF676270956F04A694,0,,0.825
+
+# Hyperion
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Hyperion,DamageScale_36_150C89A04BB4FCF0061CAC86E39E1A39,0,,1.437
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Hyperion,CritDamageScale_63_CD26C16D40CD2DDF676270956F04A694,0,,0.675
+
+# Vladof
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Vladof,DamageScale_36_150C89A04BB4FCF0061CAC86E39E1A39,0,,2.447
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Vladof,CritDamageScale_63_CD26C16D40CD2DDF676270956F04A694,0,,0.6
+
+# Tediore
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Tediore,DamageScale_36_150C89A04BB4FCF0061CAC86E39E1A39,0,,1.52
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Tediore,CritDamageScale_63_CD26C16D40CD2DDF676270956F04A694,0,,0.625
+
+# COV
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,CoV,DamageScale_36_150C89A04BB4FCF0061CAC86E39E1A39,0,,2.036
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,CoV,CritDamageScale_63_CD26C16D40CD2DDF676270956F04A694,0,,0.6
+
+# Maliwan
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Maliwan,DamageScale_36_150C89A04BB4FCF0061CAC86E39E1A39,0,,0.782
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Maliwan,CritDamageScale_63_CD26C16D40CD2DDF676270956F04A694,0,,0.575
+
+# Atlas
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Atlas,DamageScale_36_150C89A04BB4FCF0061CAC86E39E1A39,0,,1.666
+SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),/Game/Gear/Weapons/_Shared/_Design/GameplayAttributes/Weapon_Initialization/DataTable_Weapon_Manufacturer_Base_Data.DataTable_Weapon_Manufacturer_Base_Data,Atlas,CritDamageScale_63_CD26C16D40CD2DDF676270956F04A694,0,,0.6


### PR DESCRIPTION
This mod changes the way critical damage is dealt. Instead of a blanket 2X modifier to the base damage of a weapon before it's calculated by any other source, It's a different modifier depending on the manufacturer. 

Jakobs now get a 50% boost in damage for crits, Dahl 30%, Hyperion 35%, Vladof 20%, COV 20%, Maliwan 15%, Atlas 20%, and Torgue is unchanged as of now. 

The base damage of each of these weapons had been brought up to the point where the final damage with their new critical modifier is EXACTLY THE SAME as it was when the modifier was 2X. This leads to a high body shot damage for each weapon. After the change, Dahl was given a 4% base damage nerf, Hyperion a 5% damage nerf, 6% damage perf for COV and Valdof, and a 7% nerf for Mailwan, all to compensate for the skill reduction inherent in this new system. Atlas weapons have their own damage changes adjusted to incentivize users to use smart bullets. No need to worry about your puck hitting a non critical location on an enemy, which further incentivizes using the tracking mechanic.  

The base strength of each of these weapons is based on the EpicNNG's Borderlands 3 Redux mod. https://github.com/BLCM/bl3mods/wiki/Redux%20Mod

This is my first mod! And I would appreciate feedback.