### PR TITLE
Update V1.4.0 Raid on Bloodsun Canyon

### DIFF
--- a/skruntskrunt/raid/README.md
+++ b/skruntskrunt/raid/README.md
@@ -29,7 +29,7 @@ Header
 Changelog
 =========
 **v1.4.0** - 2021-03-12
- * More automation, more mobs, better control of loot by style
+ * More automation, more bosses, better control of loot by style
 
 **v1.3.0** - 2021-03-04
  * First versioned release

--- a/skruntskrunt/raid/README.md
+++ b/skruntskrunt/raid/README.md
@@ -19,7 +19,7 @@ Balance help is appreciated.
 Header
 ======
 * Name: Raid on Bloodsun Canyon, Raid on VIP Tower, and Raid Bosses
-* Version: 1.3.0
+* Version: 1.4.0
 * Author: Abram/skruntskrunt,  Apocalyptech, EpicNNG, Grimm, and more
 * Categories: enemy-drops, loot-system, mode-balance, enemy
 * License: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
@@ -28,6 +28,8 @@ Header
 
 Changelog
 =========
+**v1.4.0** - 2021-03-12
+ * More automation, more mobs, better control of loot by style
 
 **v1.3.0** - 2021-03-04
  * First versioned release

--- a/skruntskrunt/raid/README.md
+++ b/skruntskrunt/raid/README.md
@@ -1,5 +1,5 @@
 Name: Raid on Bloodsun Canyon, Raid on VIP Tower, and Raid Bosses
-======================
+=================================================================
 
 * The Raid on Bloodsun Canyon: Fight all the named enemies in
   Bloosun Canyon who now have the strength of invincible raid boses.
@@ -14,7 +14,20 @@ stronger, and drop a lot more loot. Bosses tend to drop a lot of their
 dedicated loot pool making the long fight worthwhile as you can pick
 up the annoint you were looking for.
 
-Balance help is appreciated.
+Tougher Bosses include:
+* Graveward
+* Ruiner
+* Troy
+* Tyreen
+* Captain Traunt 
+* General Traunt 
+* Rampager
+* Power Rangers
+* Trail bosses
+* etc.
+
+Balance help is appreciated. The underlying philosophy is that a big
+spongey raid boss fight makes you deserving of dedicated drops.
 
 Header
 ======
@@ -43,3 +56,27 @@ The generation script for the mod is licensed under the
 [GPLv3 or later](https://www.gnu.org/licenses/quick-guide-gplv3.html).
 See [COPYING.txt](../../COPYING.txt) for the full text of the license.
 
+Development Home
+================
+
+This mod is being developed on the raid branch of:
+
+https://github.com/abramhindle/bl3mods
+
+You can get latest versions there. Pull requests, patches, and
+feedback (as issues) are welcome.
+
+Bug reporting
+=============
+
+Please report bugs to this repository on github: https://github.com/abramhindle/bl3mods
+
+Dev Instructions
+================
+
+If you want to modify the software raid.py is the main generator of the hotfix.
+
+* raid.py - main program
+* raid.bl3hotfix.HEAD - header that is added to the head of raid.py output
+* raid.bl3hotfix - generated via `python3 raid.py > raid.bl3hotfix`
+* README.md - this readme

--- a/skruntskrunt/raid/raid.bl3hotfix
+++ b/skruntskrunt/raid/raid.bl3hotfix
@@ -29,17 +29,17 @@
 # [X] One punch drops?
 # [X] Trufflemunch drops
 # [X] Lavender Crawly seemed broken?
-# [ ] Multiplayer demoskagon weird
-# [ ] Buff Chupab
-# [ ] Eista spawns loot in a meaningful way
-# [ ] Too strong militant near one punch
+# [X] Multiplayer demoskagon weird
 # [X] add kratch
-# [ ] Rax
-# [ ] Max
-# [ ] El Dragon
-# [ ] Power Rangers
-# [ ] Psycho Billies
-# [ ] Katagawa Ball
+# [-] Buff Chupab
+# [-] Rax
+# [-] Max
+# [-] El Dragon
+# [-] Power Rangers
+# [-] Psycho Billies
+# [-] Katagawa Ball
+# [ ] Too strong militant near one punch
+# [ ] Eista spawns loot in a meaningful way
 
 # Graveward
 SparkCharacterLoadedEntry,(1,2,0,BPChar_EdenBoss),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Graveward,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1

--- a/skruntskrunt/raid/raid.bl3hotfix
+++ b/skruntskrunt/raid/raid.bl3hotfix
@@ -521,6 +521,16 @@ SparkCharacterLoadedEntry,(1,1,0,BPChar_GerPunkGreg_Rakk),/Geranium/Enemies/GerP
 SparkCharacterLoadedEntry,(1,1,0,BPChar_GerPunkGreg_Rakk),/Geranium/Enemies/GerPunk_Female/_Unique/Greg/_Design/Character/BPChar_GerPunkGreg_Rakk.BPChar_GerPunkGreg_Rakk_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=7,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 
 
+#########
+# Ruiner (Manual)
+# The Ruiner from loot randomizer
+SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/ItemPool_RuinerBoss.ItemPool_RuinerBoss,BalancedItems.BalancedItems[0].InventoryBalanceData,0,,None
+SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/ItemPool_RuinerBoss.ItemPool_RuinerBoss,BalancedItems.BalancedItems[0].ResolvedInventoryBalanceData,0,,None
+SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/ItemPool_RuinerBoss.ItemPool_RuinerBoss,BalancedItems.BalancedItems[0].ItemPoolData,0,,ItemPoolData'"/Game/GameData/Loot/ItemPools/Guns/Pistols/ItemPool_Pistols_Legendary.ItemPool_Pistols_Legendary"'
+
+############################ Insert raid.py output here #############
+
+
 ##### Tyreen #####
 # BPChar: BPChar_FinalBoss
 # bpchar_path: /Game/Enemies/FinalBoss/_Shared/_Design/Character/BPChar_FinalBoss
@@ -531,6 +541,9 @@ SparkCharacterLoadedEntry,(1,1,0,BPChar_FinalBoss),/Game/Enemies/FinalBoss/_Shar
 SparkCharacterLoadedEntry,(1,1,0,BPChar_FinalBoss),/Game/Enemies/FinalBoss/_Shared/_Design/Character/BPChar_FinalBoss.BPChar_FinalBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,2,0,BPChar_FinalBoss),/Game/Enemies/FinalBoss/_Shared/_Design/Balance/Table_Balance_FinalBoss_PT1.Table_Balance_FinalBoss_PT1,FinalBoss,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_FinalBoss),/Game/Enemies/FinalBoss/_Shared/_Design/Balance/Table_Balance_FinalBoss_PT1.Table_Balance_FinalBoss_PT1,FinalBoss,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_FinalBoss),/Game/Enemies/FinalBoss/_Shared/_Design/Balance/Table_Balance_FinalBoss_PT1.Table_Balance_FinalBoss_PT1,FinalBoss,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_FinalBoss),/Game/Enemies/FinalBoss/_Shared/_Design/Balance/Table_Balance_FinalBoss_PT1.Table_Balance_FinalBoss_PT1,FinalBoss,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_FinalBoss),/Game/Enemies/FinalBoss/_Shared/_Design/Balance/Table_Balance_FinalBoss_PT1.Table_Balance_FinalBoss_PT1,FinalBoss,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_FinalBoss),/Game/Enemies/FinalBoss/_Shared/_Design/Balance/Table_Balance_FinalBoss_PT1.Table_Balance_FinalBoss_PT1,FinalBoss,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -545,6 +558,9 @@ SparkCharacterLoadedEntry,(1,1,0,BPChar_TroyBoss),/Game/NonPlayerCharacters/Troy
 SparkCharacterLoadedEntry,(1,1,0,BPChar_TroyBoss),/Game/NonPlayerCharacters/Troy/_TheBoss/_Design/Character/BPChar_TroyBoss.BPChar_TroyBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,2,0,BPChar_TroyBoss),/Game/NonPlayerCharacters/Troy/_Design/Balance/Table_Balance_TroyBoss_PT1.Table_Balance_TroyBoss_PT1,TroyBoss,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_TroyBoss),/Game/NonPlayerCharacters/Troy/_Design/Balance/Table_Balance_TroyBoss_PT1.Table_Balance_TroyBoss_PT1,TroyBoss,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TroyBoss),/Game/NonPlayerCharacters/Troy/_Design/Balance/Table_Balance_TroyBoss_PT1.Table_Balance_TroyBoss_PT1,TroyBoss,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TroyBoss),/Game/NonPlayerCharacters/Troy/_Design/Balance/Table_Balance_TroyBoss_PT1.Table_Balance_TroyBoss_PT1,TroyBoss,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TroyBoss),/Game/NonPlayerCharacters/Troy/_Design/Balance/Table_Balance_TroyBoss_PT1.Table_Balance_TroyBoss_PT1,TroyBoss,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_TroyBoss),/Game/NonPlayerCharacters/Troy/_Design/Balance/Table_Balance_TroyBoss_PT1.Table_Balance_TroyBoss_PT1,TroyBoss,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -557,12 +573,9 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_TroyBoss),/Game/NonPlayerCharacters/Troy
 
 SparkCharacterLoadedEntry,(1,1,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/Rampager/_Design/Character/BPChar_Rampager.BPChar_Rampager_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,1,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/Rampager/_Design/Character/BPChar_Rampager.BPChar_Rampager_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-
-
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1.Table_Balance_PromBoss_PT1,Rampager,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1.Table_Balance_PromBoss_PT1,Rampager,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1.Table_Balance_PromBoss_PT1,Rampager,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,4000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1.Table_Balance_PromBoss_PT1,Rampager,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,4000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1.Table_Balance_PromBoss_PT1,Rampager,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
-
 
 
 
@@ -573,7 +586,7 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/_S
 # balance rowname: Ruiner_Boss_PT2
 
 SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/BPChar_RuinerBoss.BPChar_RuinerBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/BPChar_RuinerBoss.BPChar_RuinerBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/BPChar_RuinerBoss.BPChar_RuinerBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=20,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,2,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/_Shared/_Design/Balance/Table_Ruiner_Balance.Table_Ruiner_Balance,Ruiner_Boss_PT2,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,3000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/_Shared/_Design/Balance/Table_Ruiner_Balance.Table_Ruiner_Balance,Ruiner_Boss_PT2,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,3000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/_Shared/_Design/Balance/Table_Ruiner_Balance.Table_Ruiner_Balance,Ruiner_Boss_PT2,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,3000
@@ -583,31 +596,20 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/_Sh
 
 
 
-
-
-
-# The Ruiner from loot randomizer
-SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/ItemPool_RuinerBoss.ItemPool_RuinerBoss,BalancedItems.BalancedItems[0].InventoryBalanceData,0,,None
-SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/ItemPool_RuinerBoss.ItemPool_RuinerBoss,BalancedItems.BalancedItems[0].ResolvedInventoryBalanceData,0,,None
-SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/ItemPool_RuinerBoss.ItemPool_RuinerBoss,BalancedItems.BalancedItems[0].ItemPoolData,0,,ItemPoolData'"/Game/GameData/Loot/ItemPools/Guns/Pistols/ItemPool_Pistols_Legendary.ItemPool_Pistols_Legendary"'
-
-
-
-
-
 ##### Minosaur #####
 # BPChar: BPChar_GerSaurianSaurtaur
 # bpchar_path: /Geranium/Enemies/GerSaurian/_Unique/Saurtaur/_Design/Character/BPChar_GerSaurianSaurtaur
 # balance_table: /Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique
 # balance rowname: GerSaurian_Saurtaur
-# 1000 is a bit strong
 
 SparkCharacterLoadedEntry,(1,1,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/GerSaurian/_Unique/Saurtaur/_Design/Character/BPChar_GerSaurianSaurtaur.BPChar_GerSaurianSaurtaur_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,1,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/GerSaurian/_Unique/Saurtaur/_Design/Character/BPChar_GerSaurianSaurtaur.BPChar_GerSaurianSaurtaur_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,2,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique.Table_GerSaurian_Balance_Unique,GerSaurian_Saurtaur,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique.Table_GerSaurian_Balance_Unique,GerSaurian_Saurtaur,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique.Table_GerSaurian_Balance_Unique,GerSaurian_Saurtaur,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique.Table_GerSaurian_Balance_Unique,GerSaurian_Saurtaur,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique.Table_GerSaurian_Balance_Unique,GerSaurian_Saurtaur,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique.Table_GerSaurian_Balance_Unique,GerSaurian_Saurtaur,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
-
 
 
 
@@ -621,6 +623,9 @@ SparkCharacterLoadedEntry,(1,1,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/E
 SparkCharacterLoadedEntry,(1,1,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/Enforcer/_Unique/BountyPrologue/_Design/Character/BPChar_Enforcer_BountyPrologue.BPChar_Enforcer_BountyPrologue_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_BountyPrologue,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_BountyPrologue,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_BountyPrologue,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_BountyPrologue,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_BountyPrologue,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_BountyPrologue,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -635,6 +640,9 @@ SparkCharacterLoadedEntry,(1,1,0,BPChar_EnforcerSacrificeBoss),/Game/Enemies/Enf
 SparkCharacterLoadedEntry,(1,1,0,BPChar_EnforcerSacrificeBoss),/Game/Enemies/Enforcer/_Unique/SacrificeBoss/_Design/Character/BPChar_EnforcerSacrificeBoss.BPChar_EnforcerSacrificeBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerSacrificeBoss),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_Mouthpiece,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerSacrificeBoss),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_Mouthpiece,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerSacrificeBoss),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_Mouthpiece,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerSacrificeBoss),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_Mouthpiece,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerSacrificeBoss),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_Mouthpiece,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerSacrificeBoss),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_Mouthpiece,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -649,6 +657,9 @@ SparkCharacterLoadedEntry,(1,1,0,BPChar_Enforcer_Bounty01),/Game/Enemies/Enforce
 SparkCharacterLoadedEntry,(1,1,0,BPChar_Enforcer_Bounty01),/Game/Enemies/Enforcer/_Unique/Bounty01/_Design/Character/BPChar_Enforcer_Bounty01.BPChar_Enforcer_Bounty01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_Bounty01),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_Bounty01_HotKarl,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_Bounty01),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_Bounty01_HotKarl,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_Bounty01),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_Bounty01_HotKarl,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_Bounty01),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_Bounty01_HotKarl,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_Bounty01),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_Bounty01_HotKarl,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_Bounty01),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_Bounty01_HotKarl,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -663,7 +674,11 @@ SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoBadassPrologue),/Game/Enemies/Psyc
 SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoBadassPrologue),/Game/Enemies/Psycho_Male/_Unique/BadassPrologue/_Design/Character/BPChar_PsychoBadassPrologue.BPChar_PsychoBadassPrologue_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoBadassPrologue),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance.Table_Psycho_Balance,Psycho_Badass,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoBadassPrologue),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance.Table_Psycho_Balance,Psycho_Badass,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoBadassPrologue),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance.Table_Psycho_Balance,Psycho_Badass,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoBadassPrologue),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance.Table_Psycho_Balance,Psycho_Badass,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoBadassPrologue),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance.Table_Psycho_Balance,Psycho_Badass,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoBadassPrologue),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance.Table_Psycho_Balance,Psycho_Badass,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
 
 
 ##### RoadDog #####
@@ -680,7 +695,6 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare02),/Game/Enemies/Goliath/_S
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare02),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare02,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare02),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare02,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare02),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare02,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
-
 
 
 
@@ -1089,5 +1103,159 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Agonizer_9k),/Game/Enemies/Agonizer_9k/_
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Agonizer_9k),/Game/Enemies/Agonizer_9k/_Shared/Balance/Table_Balance_Agonizer_9k.Table_Balance_Agonizer_9k,A9K,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Agonizer_9k),/Game/Enemies/Agonizer_9k/_Shared/Balance/Table_Balance_Agonizer_9k.Table_Balance_Agonizer_9k,A9K,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Agonizer_9k),/Game/Enemies/Agonizer_9k/_Shared/Balance/Table_Balance_Agonizer_9k.Table_Balance_Agonizer_9k,A9K,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Wick #####
+# BPChar: BPChar_PsychoRare03
+# bpchar_path: /Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03
+# balance_table: /Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique
+# balance rowname: Rare03
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03.BPChar_PsychoRare03_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03.BPChar_PsychoRare03_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare03,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare03,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare03,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare03,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare03,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare03,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Borman Nates #####
+# BPChar: BPChar_PsychoRare02
+# bpchar_path: /Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare02
+# balance_table: /Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique
+# balance rowname: Rare02
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare02),/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare02.BPChar_PsychoRare02_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare02),/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare02.BPChar_PsychoRare02_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare02,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare02,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare02,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare02,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare02,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare02,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Warty #####
+# BPChar: BPChar_PsychoRare01
+# bpchar_path: /Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare01
+# balance_table: /Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique
+# balance rowname: Rare01
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare01.BPChar_PsychoRare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare01.BPChar_PsychoRare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare01,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare01,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare01,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare01,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare01,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare01,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### OnePunch #####
+# BPChar: BPChar_PsychoRare03
+# bpchar_path: /Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03
+# balance_table: /Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique
+# balance rowname: OnePunch
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03.BPChar_PsychoRare03_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03.BPChar_PsychoRare03_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Judge Hightower #####
+# BPChar: BPChar_AtlasSoldier_Bounty01
+# bpchar_path: /Game/NonPlayerCharacters/_Promethea/AtlasSoldier/_Design/Character/BPChar_AtlasSoldier_Bounty01
+# balance_table: /Game/NonPlayerCharacters/_Shared/_Design/Table_Balance_NPC
+# balance rowname: AtlasSoldier_Bounty
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_AtlasSoldier_Bounty01),/Game/NonPlayerCharacters/_Promethea/AtlasSoldier/_Design/Character/BPChar_AtlasSoldier_Bounty01.BPChar_AtlasSoldier_Bounty01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_AtlasSoldier_Bounty01),/Game/NonPlayerCharacters/_Promethea/AtlasSoldier/_Design/Character/BPChar_AtlasSoldier_Bounty01.BPChar_AtlasSoldier_Bounty01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_AtlasSoldier_Bounty01),/Game/NonPlayerCharacters/_Shared/_Design/Table_Balance_NPC.Table_Balance_NPC,AtlasSoldier_Bounty,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_AtlasSoldier_Bounty01),/Game/NonPlayerCharacters/_Shared/_Design/Table_Balance_NPC.Table_Balance_NPC,AtlasSoldier_Bounty,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_AtlasSoldier_Bounty01),/Game/NonPlayerCharacters/_Shared/_Design/Table_Balance_NPC.Table_Balance_NPC,AtlasSoldier_Bounty,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_AtlasSoldier_Bounty01),/Game/NonPlayerCharacters/_Shared/_Design/Table_Balance_NPC.Table_Balance_NPC,AtlasSoldier_Bounty,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_AtlasSoldier_Bounty01),/Game/NonPlayerCharacters/_Shared/_Design/Table_Balance_NPC.Table_Balance_NPC,AtlasSoldier_Bounty,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_AtlasSoldier_Bounty01),/Game/NonPlayerCharacters/_Shared/_Design/Table_Balance_NPC.Table_Balance_NPC,AtlasSoldier_Bounty,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Urist McEnforcer #####
+# BPChar: BPChar_EnforcerUrist
+# bpchar_path: /Game/Enemies/Enforcer/_Unique/Urist/_Design/Character/BPChar_EnforcerUrist
+# balance_table: /Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance
+# balance rowname: Enforcer_Shield
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_EnforcerUrist),/Game/Enemies/Enforcer/_Unique/Urist/_Design/Character/BPChar_EnforcerUrist.BPChar_EnforcerUrist_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_EnforcerUrist),/Game/Enemies/Enforcer/_Unique/Urist/_Design/Character/BPChar_EnforcerUrist.BPChar_EnforcerUrist_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerUrist),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance.Table_Enforcer_Balance,Enforcer_Shield,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerUrist),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance.Table_Enforcer_Balance,Enforcer_Shield,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerUrist),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance.Table_Enforcer_Balance,Enforcer_Shield,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerUrist),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance.Table_Enforcer_Balance,Enforcer_Shield,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerUrist),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance.Table_Enforcer_Balance,Enforcer_Shield,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerUrist),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance.Table_Enforcer_Balance,Enforcer_Shield,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Killavolt (Kenneth) #####
+# BPChar: BPChar_EnforcerKillaVolt
+# bpchar_path: /Game/Enemies/Enforcer/_Unique/KillaVolt/_Design/Character/BPChar_EnforcerKillaVolt
+# balance_table: /Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique
+# balance rowname: Enforcer_KillaVolt
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Unique/KillaVolt/_Design/Character/BPChar_EnforcerKillaVolt.BPChar_EnforcerKillaVolt_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Unique/KillaVolt/_Design/Character/BPChar_EnforcerKillaVolt.BPChar_EnforcerKillaVolt_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_KillaVolt,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_KillaVolt,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_KillaVolt,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_KillaVolt,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_KillaVolt,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_KillaVolt,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Katagawa Jr. #####
+# BPChar: BPChar_KJR
+# bpchar_path: /Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR
+# balance_table: /Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1
+# balance rowname: KatagawaJR_Boss
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_KJR),/Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR.BPChar_KJR_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_KJR),/Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR.BPChar_KJR_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1.Table_Balance_KatagawaJR_PT1,KatagawaJR_Boss,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1.Table_Balance_KatagawaJR_PT1,KatagawaJR_Boss,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1.Table_Balance_KatagawaJR_PT1,KatagawaJR_Boss,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1.Table_Balance_KatagawaJR_PT1,KatagawaJR_Boss,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1.Table_Balance_KatagawaJR_PT1,KatagawaJR_Boss,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1.Table_Balance_KatagawaJR_PT1,KatagawaJR_Boss,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Katagawa Jr (Hologram). #####
+# BPChar: BPChar_KJR
+# bpchar_path: /Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR
+# balance_table: /Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1
+# balance rowname: KatagawaJR_Hologram
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_KJR),/Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR.BPChar_KJR_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_KJR),/Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR.BPChar_KJR_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1.Table_Balance_KatagawaJR_PT1,KatagawaJR_Hologram,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1.Table_Balance_KatagawaJR_PT1,KatagawaJR_Hologram,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+
+
 
 

--- a/skruntskrunt/raid/raid.bl3hotfix
+++ b/skruntskrunt/raid/raid.bl3hotfix
@@ -666,6 +666,21 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoBadassPrologue),/Game/Enemies/Psyc
 SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoBadassPrologue),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance.Table_Psycho_Balance,Psycho_Badass,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
+##### RoadDog #####
+# BPChar: BPChar_Goliath_Rare02
+# bpchar_path: /Game/Enemies/Goliath/_Unique/Rare02/_Design/Character/BPChar_Goliath_Rare02
+# balance_table: /Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique
+# balance rowname: Rare02
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Goliath_Rare02),/Game/Enemies/Goliath/_Unique/Rare02/_Design/Character/BPChar_Goliath_Rare02.BPChar_Goliath_Rare02_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Goliath_Rare02),/Game/Enemies/Goliath/_Unique/Rare02/_Design/Character/BPChar_Goliath_Rare02.BPChar_Goliath_Rare02_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare02),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare02,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare02),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare02,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare02),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare02,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare02),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare02,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare02),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare02,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare02),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare02,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
 
 
 

--- a/skruntskrunt/raid/raid.bl3hotfix
+++ b/skruntskrunt/raid/raid.bl3hotfix
@@ -1,7 +1,7 @@
 ###
 ### Name: Raid on Bloodsun Canyon, Raid on VIP Tower, and Raid Bosses
-### Version: 1.3.0
-### Author: Abram/skruntskrunt,  Apocalyptech, EpicNNG, Grimm, and more
+### Version: 1.4.0
+### Author: Abram/skruntskrunt,  Apocalyptech, EpicNNG, Grimm, alef-4, and more
 ### Categories: enemy-drops, loot-system, mode-balance, enemy
 ###
 ### License: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
@@ -40,6 +40,9 @@
 # [-] Katagawa Ball
 # [ ] Too strong militant near one punch
 # [ ] Eista spawns loot in a meaningful way
+
+
+########## This stuff is all bespoke stolen code ##################
 
 # Graveward
 SparkCharacterLoadedEntry,(1,2,0,BPChar_EdenBoss),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Graveward,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
@@ -498,8 +501,6 @@ SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/C
 
 
 ############################ Insert raid.py output here #############
-
-
 ##### Tyreen #####
 # BPChar: BPChar_FinalBoss
 # bpchar_path: /Game/Enemies/FinalBoss/_Shared/_Design/Character/BPChar_FinalBoss
@@ -588,8 +589,8 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/Ge
 # balance_table: /Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique
 # balance rowname: Enforcer_BountyPrologue
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/Enforcer/_Unique/BountyPrologue/_Design/Character/BPChar_Enforcer_BountyPrologue.BPChar_Enforcer_BountyPrologue_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/Enforcer/_Unique/BountyPrologue/_Design/Character/BPChar_Enforcer_BountyPrologue.BPChar_Enforcer_BountyPrologue_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[43].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[43].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_BountyPrologue,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_BountyPrologue,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Enforcer_BountyPrologue),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_BountyPrologue,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
@@ -877,8 +878,8 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_ClaptrapQueen),/Game/PatchDLC/Dandelion/
 # balance_table: /Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique
 # balance rowname: Saurian_TrialBoss
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Saurian_TrialBoss),/Game/Enemies/Saurian/_Unique/TrialBoss/_Design/Character/BPChar_Saurian_TrialBoss.BPChar_Saurian_TrialBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Saurian_TrialBoss),/Game/Enemies/Saurian/_Unique/TrialBoss/_Design/Character/BPChar_Saurian_TrialBoss.BPChar_Saurian_TrialBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[60].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[60].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Saurian_TrialBoss),/Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique.Table_Balance_Saurian_Unique,Saurian_TrialBoss,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Saurian_TrialBoss),/Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique.Table_Balance_Saurian_Unique,Saurian_TrialBoss,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Saurian_TrialBoss),/Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique.Table_Balance_Saurian_Unique,Saurian_TrialBoss,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
@@ -911,8 +912,8 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Saurian_SlaughterBoss),/Game/Enemies/Sau
 # balance_table: /Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique
 # balance rowname: Tink_TrialBoss
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Tink_TrialBoss),/Game/Enemies/Tink/_Unique/TrialBoss/_Design/Character/BPChar_Tink_TrialBoss.BPChar_Tink_TrialBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Tink_TrialBoss),/Game/Enemies/Tink/_Unique/TrialBoss/_Design/Character/BPChar_Tink_TrialBoss.BPChar_Tink_TrialBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[66].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[66].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Tink_TrialBoss),/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique.Table_Balance_Tink_Unique,Tink_TrialBoss,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Tink_TrialBoss),/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique.Table_Balance_Tink_Unique,Tink_TrialBoss,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Tink_TrialBoss),/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique.Table_Balance_Tink_Unique,Tink_TrialBoss,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
@@ -928,8 +929,8 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Tink_TrialBoss),/Game/Enemies/Tink/_Shar
 # balance_table: /Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique
 # balance rowname: TrialBoss
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Skag_TrialBoss),/Game/Enemies/Skag/_Unique/TrialBoss/_Design/Character/BPChar_Skag_TrialBoss.BPChar_Skag_TrialBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Skag_TrialBoss),/Game/Enemies/Skag/_Unique/TrialBoss/_Design/Character/BPChar_Skag_TrialBoss.BPChar_Skag_TrialBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[62].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[62].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_TrialBoss),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,TrialBoss,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_TrialBoss),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,TrialBoss,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_TrialBoss),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,TrialBoss,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
@@ -979,8 +980,8 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_SlaughterBoss),/Game/Enemies/Gol
 # balance_table: /Game/Enemies/Goon/_Shared/_Design/Balance/Table_Balance_Goon_Unique
 # balance rowname: Goon_BossTrial
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Goon_TrialBoss),/Game/Enemies/Goon/_Unique/TrialBoss/_Design/Character/BPChar_Goon_TrialBoss.BPChar_Goon_TrialBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Goon_TrialBoss),/Game/Enemies/Goon/_Unique/TrialBoss/_Design/Character/BPChar_Goon_TrialBoss.BPChar_Goon_TrialBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[48].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[48].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Goon_TrialBoss),/Game/Enemies/Goon/_Shared/_Design/Balance/Table_Balance_Goon_Unique.Table_Balance_Goon_Unique,Goon_BossTrial,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Goon_TrialBoss),/Game/Enemies/Goon/_Shared/_Design/Balance/Table_Balance_Goon_Unique.Table_Balance_Goon_Unique,Goon_BossTrial,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Goon_TrialBoss),/Game/Enemies/Goon/_Shared/_Design/Balance/Table_Balance_Goon_Unique.Table_Balance_Goon_Unique,Goon_BossTrial,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
@@ -996,8 +997,8 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Goon_TrialBoss),/Game/Enemies/Goon/_Shar
 # balance_table: /Game/Enemies/Mech/_Shared/_Design/Balance/Table_Balance_Mech
 # balance rowname: Mech_TrialBoss
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Mech_TrialBoss),/Game/Enemies/Mech/_Unique/TrialBoss/_Design/Character/BPChar_Mech_TrialBoss.BPChar_Mech_TrialBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Mech_TrialBoss),/Game/Enemies/Mech/_Unique/TrialBoss/_Design/Character/BPChar_Mech_TrialBoss.BPChar_Mech_TrialBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[54].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[54].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Mech_TrialBoss),/Game/Enemies/Mech/_Shared/_Design/Balance/Table_Balance_Mech.Table_Balance_Mech,Mech_TrialBoss,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Mech_TrialBoss),/Game/Enemies/Mech/_Shared/_Design/Balance/Table_Balance_Mech.Table_Balance_Mech,Mech_TrialBoss,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Mech_TrialBoss),/Game/Enemies/Mech/_Shared/_Design/Balance/Table_Balance_Mech.Table_Balance_Mech,Mech_TrialBoss,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
@@ -1013,8 +1014,8 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Mech_TrialBoss),/Game/Enemies/Mech/_Shar
 # balance_table: /Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique
 # balance rowname: Saurian_Rare01
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Saurian_Rare01),/Game/Enemies/Saurian/_Unique/Rare01/_Design/Character/BPChar_Saurian_Rare01.BPChar_Saurian_Rare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Saurian_Rare01),/Game/Enemies/Saurian/_Unique/Rare01/_Design/Character/BPChar_Saurian_Rare01.BPChar_Saurian_Rare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[58].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[58].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Saurian_Rare01),/Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique.Table_Balance_Saurian_Unique,Saurian_Rare01,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Saurian_Rare01),/Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique.Table_Balance_Saurian_Unique,Saurian_Rare01,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Saurian_Rare01),/Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique.Table_Balance_Saurian_Unique,Saurian_Rare01,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
@@ -1030,16 +1031,12 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Saurian_Rare01),/Game/Enemies/Saurian/_S
 # balance_table: /Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique
 # balance rowname: DemoSkag
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Unique/Rare01/_Design/Character/BPChar_Skag_Rare01.BPChar_Skag_Rare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Unique/Rare01/_Design/Character/BPChar_Skag_Rare01.BPChar_Skag_Rare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[61].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[61].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,500.0
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
-# /Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds
+
 
 ##### Warden #####
 # BPChar: BPChar_Goliath_CageArena
@@ -1115,8 +1112,8 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/Enemies/Psycho_Male/
 # balance_table: /Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique
 # balance rowname: Rare01
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare01.BPChar_PsychoRare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare01.BPChar_PsychoRare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[64].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[64].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
 SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare01,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare01,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,Rare01,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
@@ -1232,11 +1229,10 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_D
 
 SparkCharacterLoadedEntry,(1,1,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/_Unique/Hunt_Kratch/Character/BPChar_SlugBadass_Kratch.BPChar_SlugBadass_Kratch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,1,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/_Unique/Hunt_Kratch/Character/BPChar_SlugBadass_Kratch.BPChar_SlugBadass_Kratch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
 SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -1281,8 +1277,8 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_ServiceBot_LOOT),/Game/Enemies/ServiceBo
 # balance_table: /Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique
 # balance rowname: Heavy_Traunt
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Unique/Traunt/_Design/Character/BPChar_Heavy_Traunt.BPChar_Heavy_Traunt_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Unique/Traunt/_Design/Character/BPChar_Heavy_Traunt.BPChar_Heavy_Traunt_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[51].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[51].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
@@ -1298,8 +1294,8 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Share
 # balance_table: /Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique
 # balance rowname: Heavy_Traunt
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Unique/DarkTraunt/_Design/Character/BPChar_HeavyDarkTraunt.BPChar_HeavyDarkTraunt_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Unique/DarkTraunt/_Design/Character/BPChar_HeavyDarkTraunt.BPChar_HeavyDarkTraunt_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[52].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[52].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
 SparkCharacterLoadedEntry,(1,2,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
@@ -1349,30 +1345,22 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_TinkUndertaker),/Game/Enemies/Tink/_Shar
 # balance_table: /Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique
 # balance rowname: Trufflemunch
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Unique/Trufflemunch/_Design/Character/BPChar_SkagTrufflemunch.BPChar_SkagTrufflemunch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Unique/Trufflemunch/_Design/Character/BPChar_SkagTrufflemunch.BPChar_SkagTrufflemunch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[89].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[89].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,500.0
 SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
 
-##### Buttmuch #####
+##### Buttmunch #####
 # BPChar: BPChar_SkagButtmunch
 # bpchar_path: /Game/Enemies/Skag/_Unique/Buttmunch/_Design/Character/BPChar_SkagButtmunch
 # balance_table: /Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique
 # balance rowname: Buttmunch
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Unique/Buttmunch/_Design/Character/BPChar_SkagButtmunch.BPChar_SkagButtmunch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Unique/Buttmunch/_Design/Character/BPChar_SkagButtmunch.BPChar_SkagButtmunch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[88].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[88].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,500.0
 SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -1442,4 +1430,278 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaD),/Game/Enemies/Varki
 SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaD),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaD),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaD),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Chupacabratch #####
+# BPChar: BPChar_Ratch_Hunt01
+# bpchar_path: /Game/Enemies/Ratch/_Unique/Hunt01/_Design/Character/BPChar_Ratch_Hunt01
+# balance_table: /Game/Enemies/Ratch/_Shared/_Design/Balance/Table_Balance_Ratch_Unique
+# balance rowname: Ratch_01Hunt
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Ratch_Hunt01),/Game/Enemies/Ratch/_Unique/Hunt01/_Design/Character/BPChar_Ratch_Hunt01.BPChar_Ratch_Hunt01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Ratch_Hunt01),/Game/Enemies/Ratch/_Unique/Hunt01/_Design/Character/BPChar_Ratch_Hunt01.BPChar_Ratch_Hunt01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/Enemies/Ratch/_Shared/_Design/Balance/Table_Balance_Ratch_Unique.Table_Balance_Ratch_Unique,Ratch_01Hunt,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/Enemies/Ratch/_Shared/_Design/Balance/Table_Balance_Ratch_Unique.Table_Balance_Ratch_Unique,Ratch_01Hunt,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/Enemies/Ratch/_Shared/_Design/Balance/Table_Balance_Ratch_Unique.Table_Balance_Ratch_Unique,Ratch_01Hunt,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/Enemies/Ratch/_Shared/_Design/Balance/Table_Balance_Ratch_Unique.Table_Balance_Ratch_Unique,Ratch_01Hunt,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/Enemies/Ratch/_Shared/_Design/Balance/Table_Balance_Ratch_Unique.Table_Balance_Ratch_Unique,Ratch_01Hunt,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/Enemies/Ratch/_Shared/_Design/Balance/Table_Balance_Ratch_Unique.Table_Balance_Ratch_Unique,Ratch_01Hunt,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Private Beans #####
+# BPChar: BPChar_NogBeans
+# bpchar_path: /Game/Enemies/Nog/_Unique/Beans/_Design/Character/BPChar_NogBeans
+# balance_table: /Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog
+# balance rowname: Nog_Badass
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_NogBeans),/Game/Enemies/Nog/_Unique/Beans/_Design/Character/BPChar_NogBeans.BPChar_NogBeans_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_NogBeans),/Game/Enemies/Nog/_Unique/Beans/_Design/Character/BPChar_NogBeans.BPChar_NogBeans_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Rax #####
+# BPChar: BPChar_TrooperBounty02
+# bpchar_path: /Game/Enemies/Trooper/_Unique/Bounty02/Design/Character/BPChar_TrooperBounty02
+# balance_table: /Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique
+# balance rowname: Trooper_Bounty02
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[91].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[91].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty02),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Bounty02,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty02),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Bounty02,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty02),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Bounty02,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty02),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Bounty02,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty02),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Bounty02,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty02),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Bounty02,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Max #####
+# BPChar: BPChar_TrooperBounty03
+# bpchar_path: /Game/Enemies/Trooper/_Unique/Bounty02/Design/Character/BPChar_TrooperBounty03
+# balance_table: /Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique
+# balance rowname: Trooper_Bounty03
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[92].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[92].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty03),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Bounty03,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty03),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Bounty03,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty03),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Bounty03,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty03),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Bounty03,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty03),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Bounty03,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty03),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Bounty03,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Force Trooper Citrine #####
+# BPChar: BPChar_Trooper_Rare01b
+# bpchar_path: /Game/Enemies/Trooper/_Unique/Rare01b/_Design/Character/BPChar_Trooper_Rare01b
+# balance_table: /Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique
+# balance rowname: Trooper_Rare01b
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[68].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[68].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Force Trooper Onyx #####
+# BPChar: BPChar_Trooper_Rare01a
+# bpchar_path: /Game/Enemies/Trooper/_Unique/Rare01a/_Design/Character/BPChar_Trooper_Rare01a
+# balance_table: /Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique
+# balance rowname: Trooper_Rare01a
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[67].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[67].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Force Trooper Ruby #####
+# BPChar: BPChar_Trooper_Rare01c
+# bpchar_path: /Game/Enemies/Trooper/_Unique/Rare01a/_Design/Character/BPChar_Trooper_Rare01c
+# balance_table: /Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique
+# balance rowname: Trooper_Rare01c
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[69].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[69].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Force Trooper Tourmaline #####
+# BPChar: BPChar_Trooper_Rare01d
+# bpchar_path: /Game/Enemies/Trooper/_Unique/Rare01a/_Design/Character/BPChar_Trooper_Rare01d
+# balance_table: /Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique
+# balance rowname: Trooper_Rare01d
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[70].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[70].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Force Trooper Tourmaline #####
+# BPChar: BPChar_Trooper_Rare01e
+# bpchar_path: /Game/Enemies/Trooper/_Unique/Rare01a/_Design/Character/BPChar_Trooper_Rare01e
+# balance_table: /Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique
+# balance rowname: Trooper_Rare01e
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[71].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[71].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### El Dragón Jr. #####
+# BPChar: BPChar_Goliath_Rare03
+# bpchar_path: /Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03
+# balance_table: /Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03
+# balance rowname: Rare03
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Goliath_Rare03),/Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03.BPChar_Goliath_Rare03_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Goliath_Rare03),/Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03.BPChar_Goliath_Rare03_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare03),/Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03.BPChar_Goliath_Rare03,Rare03,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare03),/Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03.BPChar_Goliath_Rare03,Rare03,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare03),/Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03.BPChar_Goliath_Rare03,Rare03,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare03),/Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03.BPChar_Goliath_Rare03,Rare03,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare03),/Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03.BPChar_Goliath_Rare03,Rare03,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare03),/Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03.BPChar_Goliath_Rare03,Rare03,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Killavolt (Kenneth) #####
+# BPChar: BPChar_EnforcerKillaVolt
+# bpchar_path: /Game/Enemies/Enforcer/_Unique/KillaVolt/_Design/Character/BPChar_EnforcerKillaVolt
+# balance_table: /Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique
+# balance rowname: Enforcer_KillaVolt
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Unique/KillaVolt/_Design/Character/BPChar_EnforcerKillaVolt.BPChar_EnforcerKillaVolt_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Unique/KillaVolt/_Design/Character/BPChar_EnforcerKillaVolt.BPChar_EnforcerKillaVolt_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_KillaVolt,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_KillaVolt,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_KillaVolt,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_KillaVolt,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_KillaVolt,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EnforcerKillaVolt),/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique.Table_Enforcer_Balance_Unique,Enforcer_KillaVolt,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Pyschobillies (d) #####
+# BPChar: BPChar_Punk_Bounty01d
+# bpchar_path: /Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/d/BPChar_Punk_Bounty01d
+# balance_table: /Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique
+# balance rowname: Punk_Bounty02
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Punk_Bounty01d),/Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/d/BPChar_Punk_Bounty01d.BPChar_Punk_Bounty01d_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Punk_Bounty01d),/Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/d/BPChar_Punk_Bounty01d.BPChar_Punk_Bounty01d_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01d),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01d),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01d),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01d),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01d),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01d),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Pyschobillies (c) #####
+# BPChar: BPChar_Punk_Bounty01c
+# bpchar_path: /Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/c/BPChar_Punk_Bounty01c
+# balance_table: /Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique
+# balance rowname: Punk_Bounty02
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Punk_Bounty01c),/Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/c/BPChar_Punk_Bounty01c.BPChar_Punk_Bounty01c_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Punk_Bounty01c),/Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/c/BPChar_Punk_Bounty01c.BPChar_Punk_Bounty01c_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01c),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01c),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01c),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01c),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01c),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01c),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Pyschobillies (b) #####
+# BPChar: BPChar_Punk_Bounty01b
+# bpchar_path: /Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/b/BPChar_Punk_Bounty01b
+# balance_table: /Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique
+# balance rowname: Punk_Bounty02
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Punk_Bounty01b),/Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/b/BPChar_Punk_Bounty01b.BPChar_Punk_Bounty01b_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Punk_Bounty01b),/Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/b/BPChar_Punk_Bounty01b.BPChar_Punk_Bounty01b_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01b),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01b),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01b),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01b),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01b),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01b),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Pyschobillies (a) #####
+# BPChar: BPChar_Punk_Bounty01a
+# bpchar_path: /Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/a/BPChar_Punk_Bounty01a
+# balance_table: /Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique
+# balance rowname: Punk_Bounty02
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Punk_Bounty01a),/Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/a/BPChar_Punk_Bounty01a.BPChar_Punk_Bounty01a_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Punk_Bounty01a),/Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/a/BPChar_Punk_Bounty01a.BPChar_Punk_Bounty01a_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01a),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01a),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01a),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01a),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01a),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Punk_Bounty01a),/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique.Table_Balance_Punk_Unique,Punk_Bounty02,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Katagawa Ball #####
+# BPChar: BPChar_Oversphere_KatagawaSphere
+# bpchar_path: /Game/Enemies/Oversphere/_Unique/KatagawaSphere/_Design/Character/BPChar_Oversphere_KatagawaSphere
+# balance_table: /Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique
+# balance rowname: Oversphere_Katagawa
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Oversphere_KatagawaSphere),/Game/Enemies/Oversphere/_Unique/KatagawaSphere/_Design/Character/BPChar_Oversphere_KatagawaSphere.BPChar_Oversphere_KatagawaSphere_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Oversphere_KatagawaSphere),/Game/Enemies/Oversphere/_Unique/KatagawaSphere/_Design/Character/BPChar_Oversphere_KatagawaSphere.BPChar_Oversphere_KatagawaSphere_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Oversphere_KatagawaSphere),/Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique.Table_Balance_Oversphere_Unique,Oversphere_Katagawa,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Oversphere_KatagawaSphere),/Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique.Table_Balance_Oversphere_Unique,Oversphere_Katagawa,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Oversphere_KatagawaSphere),/Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique.Table_Balance_Oversphere_Unique,Oversphere_Katagawa,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Oversphere_KatagawaSphere),/Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique.Table_Balance_Oversphere_Unique,Oversphere_Katagawa,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Oversphere_KatagawaSphere),/Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique.Table_Balance_Oversphere_Unique,Oversphere_Katagawa,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Oversphere_KatagawaSphere),/Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique.Table_Balance_Oversphere_Unique,Oversphere_Katagawa,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
 

--- a/skruntskrunt/raid/raid.bl3hotfix
+++ b/skruntskrunt/raid/raid.bl3hotfix
@@ -23,6 +23,10 @@
 ### Balance help is appreciated
 
 # TODOS:
+# [ ] Captain Traunt Drops
+# [ ] Demoskagon Drops
+# [ ] Trufflemunch drops
+# [ ] Lavender Crawly seemed broken?
 # [ ] Eista spawns loot in a meaningful way
 # [ ] One punch drops?
 # [ ] Urist McEnforcer
@@ -394,6 +398,31 @@ SparkCharacterLoadedEntry,(1,1,0,BPChar_GerPunkGreg_Rakk),/Geranium/Enemies/GerP
 SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/ItemPool_RuinerBoss.ItemPool_RuinerBoss,BalancedItems.BalancedItems[0].InventoryBalanceData,0,,None
 SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/ItemPool_RuinerBoss.ItemPool_RuinerBoss,BalancedItems.BalancedItems[0].ResolvedInventoryBalanceData,0,,None
 SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/ItemPool_RuinerBoss.ItemPool_RuinerBoss,BalancedItems.BalancedItems[0].ItemPoolData,0,,ItemPoolData'"/Game/GameData/Loot/ItemPools/Guns/Pistols/ItemPool_Pistols_Legendary.ItemPool_Pistols_Legendary"'
+
+########
+# Demoskaggon (Manual)
+# Loot
+
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,DemoSkag,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,DemoSkag,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,DemoSkag,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPools/ItemPool_DemoSkaggon.ItemPool_DemoSkaggon,Quantity,0,,(BaseValueConstant=12)
+
+##### Captain Traunt (Manual) #####
+# BPChar: BPChar_Heavy_Traunt
+# bpchar_path: /Game/Enemies/Heavy/_Unique/Traunt/_Design/Character/BPChar_Heavy_Traunt
+# balance_table: /Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique
+# balance rowname: Heavy_Traunt
+
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,DemoSkag,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,DemoSkag,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,DemoSkag,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+# SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPools/ItemPool_CaptTraunt.ItemPool_CaptTraunt,Quantity,0,,(BaseValueConstant=12)
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[51].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[51].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+
+
 
 ############################ Insert raid.py output here #############
 
@@ -930,14 +959,14 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Saurian_Rare01),/Game/Enemies/Saurian/_S
 
 SparkCharacterLoadedEntry,(1,1,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Unique/Rare01/_Design/Character/BPChar_Skag_Rare01.BPChar_Skag_Rare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,1,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Unique/Rare01/_Design/Character/BPChar_Skag_Rare01.BPChar_Skag_Rare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,100
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,100
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,100
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,100
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,100
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
-
+# /Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds
 
 ##### Warden #####
 # BPChar: BPChar_Goliath_CageArena

--- a/skruntskrunt/raid/raid.bl3hotfix
+++ b/skruntskrunt/raid/raid.bl3hotfix
@@ -445,6 +445,18 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/GameData/Loot/ItemPo
 SparkCharacterLoadedEntry,(1,1,0,BPChar_Ratch_Hunt01),/Game/GameData/Loot/ItemPools/Unique/ItemPool_BloodSucker_Chupacabratch.ItemPool_BloodSucker_Chupacabratch,Quantity,0,,(BaseValueConstant=7,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 
 
+# Borman Nates
+
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,BoremanNates,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,BoremanNates,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,BoremanNates,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare02),/Game/Enemies/Psycho_Male/_Unique/Rare02/_Design/Character/BPChar_PsychoRare02.BPChar_PsychoRare02_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare02),/Game/GameData/Loot/ItemPools/Unique/ItemPool_PsychoStabber_BormanNates.ItemPool_PsychoStabber_BormanNates,Quantity,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+
 
 
 ############################ Insert raid.py output here #############

--- a/skruntskrunt/raid/raid.bl3hotfix
+++ b/skruntskrunt/raid/raid.bl3hotfix
@@ -29,10 +29,17 @@
 # [X] One punch drops?
 # [X] Trufflemunch drops
 # [X] Lavender Crawly seemed broken?
+# [ ] Multiplayer demoskagon weird
+# [ ] Buff Chupab
 # [ ] Eista spawns loot in a meaningful way
 # [ ] Too strong militant near one punch
 # [X] add kratch
-# [ ] 
+# [ ] Rax
+# [ ] Max
+# [ ] El Dragon
+# [ ] Power Rangers
+# [ ] Psycho Billies
+# [ ] Katagawa Ball
 
 # Graveward
 SparkCharacterLoadedEntry,(1,2,0,BPChar_EdenBoss),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Graveward,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
@@ -455,6 +462,37 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/GameData/Loot/ItemPo
 SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare02),/Game/Enemies/Psycho_Male/_Unique/Rare02/_Design/Character/BPChar_PsychoRare02.BPChar_PsychoRare02_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 
 SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare02),/Game/GameData/Loot/ItemPools/Unique/ItemPool_PsychoStabber_BormanNates.ItemPool_PsychoStabber_BormanNates,Quantity,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+
+
+# Hag of Fervor
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[48].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[48].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,2
+
+# Sera of Supremacy
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[49].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[49].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,2
+
+# Arbalest of Discipline
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[54].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[54].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,2
+
+# Tyrant of Instinct
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[60].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[60].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,2
+
+# Skag of Survival
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[62].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[62].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,2
+
+# Tink of Cunning
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[66].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[66].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,2
+
+# Indo Tyrant
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[58].DropOnDeathItemPools.ItemPools,0,,((ItemPool=ItemPool'"/Game/PatchDLC/Raid1/GameData/Loot/ItemPools/ItemPool_IndoTyrant.ItemPool_IndoTyrant"',PoolProbability=(BaseValueConstant=1),NumberOfTimesToSelectFromThisPool=(BaseValueConstant=3)),(ItemPool=ItemPool'"/Game/GameData/Loot/ItemPools/ItemPool_SkinsAndMisc.ItemPool_SkinsAndMisc"',PoolProbability=(BaseValueConstant=1),NumberOfTimesToSelectFromThisPool=(BaseValueConstant=1)))
+
+
 
 
 
@@ -994,11 +1032,11 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Saurian_Rare01),/Game/Enemies/Saurian/_S
 
 SparkCharacterLoadedEntry,(1,1,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Unique/Rare01/_Design/Character/BPChar_Skag_Rare01.BPChar_Skag_Rare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,1,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Unique/Rare01/_Design/Character/BPChar_Skag_Rare01.BPChar_Skag_Rare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,100
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,100
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,100
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,100
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,100
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,DemoSkag,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 # /Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds

--- a/skruntskrunt/raid/raid.bl3hotfix
+++ b/skruntskrunt/raid/raid.bl3hotfix
@@ -31,12 +31,16 @@
 # [X] Lavender Crawly seemed broken?
 # [X] Multiplayer demoskagon weird
 # [X] add kratch
-# [-] Buff Chupab
-# [-] Rax
-# [-] Max
-# [-] El Dragon
-# [-] Power Rangers
-# [-] Psycho Billies
+# [X] Beans?
+# [X] Buff Chupab
+# [-] Trials?
+# [X] Rax
+# [X] Max
+# [X] El Dragon
+# [X] Power Rangers
+# [X] Psycho Billies
+# [ ] Arbalest wasn't buffed :(
+# [-] Sera of whatever isn't dropping mad loot?
 # [-] Katagawa Ball
 # [ ] Too strong militant near one punch
 # [ ] Eista spawns loot in a meaningful way
@@ -946,8 +950,8 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_TrialBoss),/Game/Enemies/Skag/_Shar
 # balance_table: /Game/Enemies/Guardian/_Shared/_Design/Balance/Table_Balance_Guardian_Unique
 # balance rowname: Guardian_Trial_Boss
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Guardian_TrialBoss),/Game/Enemies/Guardian/_Unique/TrialBoss/_Design/Character/BPChar_Guardian_TrialBoss.BPChar_Guardian_TrialBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_Guardian_TrialBoss),/Game/Enemies/Guardian/_Unique/TrialBoss/_Design/Character/BPChar_Guardian_TrialBoss.BPChar_Guardian_TrialBoss_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[49].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[49].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Guardian_TrialBoss),/Game/Enemies/Guardian/_Shared/_Design/Balance/Table_Balance_Guardian_Unique.Table_Balance_Guardian_Unique,Guardian_Trial_Boss,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Guardian_TrialBoss),/Game/Enemies/Guardian/_Shared/_Design/Balance/Table_Balance_Guardian_Unique.Table_Balance_Guardian_Unique,Guardian_Trial_Boss,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Guardian_TrialBoss),/Game/Enemies/Guardian/_Shared/_Design/Balance/Table_Balance_Guardian_Unique.Table_Balance_Guardian_Unique,Guardian_Trial_Boss,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
@@ -1458,11 +1462,11 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/Enemies/Ratch/_Share
 
 SparkCharacterLoadedEntry,(1,1,0,BPChar_NogBeans),/Game/Enemies/Nog/_Unique/Beans/_Design/Character/BPChar_NogBeans.BPChar_NogBeans_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,1,0,BPChar_NogBeans),/Game/Enemies/Nog/_Unique/Beans/_Design/Character/BPChar_NogBeans.BPChar_NogBeans_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,666.6666666666666
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,666.6666666666666
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,666.6666666666666
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,666.6666666666666
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,666.6666666666666
 SparkCharacterLoadedEntry,(1,2,0,BPChar_NogBeans),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog.Table_Balance_Nog,Nog_Badass,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -1509,11 +1513,11 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_TrooperBounty03),/Game/Enemies/Trooper/_
 
 SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[68].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[68].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,500.0
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01b,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -1526,11 +1530,11 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01b),/Game/Enemies/Trooper/_
 
 SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[67].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[67].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,500.0
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01a,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -1543,11 +1547,11 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01a),/Game/Enemies/Trooper/_
 
 SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[69].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[69].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,500.0
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01c,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -1560,11 +1564,11 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01c),/Game/Enemies/Trooper/_
 
 SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[70].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[70].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,500.0
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01d,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -1577,11 +1581,11 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01d),/Game/Enemies/Trooper/_
 
 SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[71].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[71].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250.0
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,500.0
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,500.0
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Trooper_Rare01e),/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique.Table_Balance_Trooper_Unique,Trooper_Rare01e,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -1702,6 +1706,23 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_Oversphere_KatagawaSphere),/Game/Enemies
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Oversphere_KatagawaSphere),/Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique.Table_Balance_Oversphere_Unique,Oversphere_Katagawa,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Oversphere_KatagawaSphere),/Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique.Table_Balance_Oversphere_Unique,Oversphere_Katagawa,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Oversphere_KatagawaSphere),/Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique.Table_Balance_Oversphere_Unique,Oversphere_Katagawa,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### The Unstoppable #####
+# BPChar: BPChar_Goliath_Rare01
+# bpchar_path: /Game/Enemies/Goliath/_Unique/Rare01/Character/BPChar_Goliath_Rare01
+# balance_table: /Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique
+# balance rowname: Rare01
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Goliath_Rare01),/Game/Enemies/Goliath/_Unique/Rare01/Character/BPChar_Goliath_Rare01.BPChar_Goliath_Rare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Goliath_Rare01),/Game/Enemies/Goliath/_Unique/Rare01/Character/BPChar_Goliath_Rare01.BPChar_Goliath_Rare01_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare01),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare01,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare01),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare01,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare01),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare01,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare01),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare01,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare01),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare01,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Goliath_Rare01),/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique.Table_Balance_Goliath_Unique,Rare01,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
 

--- a/skruntskrunt/raid/raid.bl3hotfix
+++ b/skruntskrunt/raid/raid.bl3hotfix
@@ -22,66 +22,11 @@
 ###
 ### Balance help is appreciated
 
-
-# [X] Graveward Buffed in Health
-# [X] Graveward Buffed in Damage
-# [X] Graveward Buffed in Drops
-
-# [X] Eista Buffed in Health
-# [X] Eista Buffed in Damage
-# [X] Eista Buffed in Drops
+# TODOS:
 # [ ] Eista spawns loot in a meaningful way
-
-# [X] Petunia in Health
-# [X] Petunia Buffed in Damage
-# [X] Petunia Buffed in Drops
-
-# [X] Dandelion in Health
-# [X] Dandelion Buffed in Damage
-# [#] Dandelion Buffed in Drops
-
-# [X] Jackbot in Health
-# [#] Balance Jack
-# [X] Jackbot Buffed in Damage
-# [X] Jackbot Buffed in Drops
-
-# [X] Jackbot in Health
-# [X] Jackbot Buffed in Damage
-# [X] Jackbot Buffed in Drops
-
-# [X] Xam and Tam in Health
-# [X] Xam and Tam Buffed in Damage
-# [X] Xam and Tam Buffed in Drops
-
-# [X] Convert Bloodsun Canyon bosses
-
-# [X] Minosaur Health
-# [X] Minosaur Damage
-# [X] Minosaur Drops
-
-# [X] Jerrick Logan Health
-# [X] Jerrick Logan Damage
-# [X] Jerrick Logan Drops
-
-# [X] Caber Dowd Health
-# [X] Caber Dowd Damage
-# [X] Caber Dowd Drops
-
-# [X] Ruiner Health
-
-# [ ] Fix Shiv Loot Pool (investigate)
-
-# [ ] Roaddog
-
-# [ ] Demoskagons
-
-# [ ] Dumptrump loot
-
-# [ ] Buff Eista just a little
 # [ ] One punch drops?
 # [ ] Urist McEnforcer
-# [ ] Too strong militant near
-#     one punch
+# [ ] Too strong militant near one punch
 # add kratch
 
 # Graveward
@@ -1176,4 +1121,223 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_D
 SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1.Table_Balance_KatagawaJR_PT1,KatagawaJR_Hologram,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
+
+##### Kratch #####
+# BPChar: BPChar_SlugBadass_Kratch
+# bpchar_path: /Hibiscus/Enemies/_Unique/Hunt_Kratch/Character/BPChar_SlugBadass_Kratch
+# balance_table: /Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1
+# balance rowname: Slug_Badass_Hunt_Kratch
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/_Unique/Hunt_Kratch/Character/BPChar_SlugBadass_Kratch.BPChar_SlugBadass_Kratch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/_Unique/Hunt_Kratch/Character/BPChar_SlugBadass_Kratch.BPChar_SlugBadass_Kratch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SlugBadass_Kratch),/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1.Table_Balance_Slug_PT1,Slug_Badass_Hunt_Kratch,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Fungal Gorger #####
+# BPChar: BPChar_Lost_Mush_Child
+# bpchar_path: /Hibiscus/Enemies/_Unique/Rare_MushroomGiant/Character/BPChar_Lost_Mush_Child
+# balance_table: /Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists
+# balance rowname: LostOne_Badass
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Lost_Mush_Child),/Hibiscus/Enemies/_Unique/Rare_MushroomGiant/Character/BPChar_Lost_Mush_Child.BPChar_Lost_Mush_Child_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Lost_Mush_Child),/Hibiscus/Enemies/_Unique/Rare_MushroomGiant/Character/BPChar_Lost_Mush_Child.BPChar_Lost_Mush_Child_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Lost_Mush_Child),/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists.Table_Balance_Cultists,LostOne_Badass,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Lost_Mush_Child),/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists.Table_Balance_Cultists,LostOne_Badass,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Lost_Mush_Child),/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists.Table_Balance_Cultists,LostOne_Badass,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Lost_Mush_Child),/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists.Table_Balance_Cultists,LostOne_Badass,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Lost_Mush_Child),/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists.Table_Balance_Cultists,LostOne_Badass,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Lost_Mush_Child),/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists.Table_Balance_Cultists,LostOne_Badass,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### AMBER LAMPS #####
+# BPChar: BPChar_ServiceBot_LOOT
+# bpchar_path: /Game/Enemies/ServiceBot/LOOT/_Design/Character/BPChar_ServiceBot_LOOT
+# balance_table: /Game/Enemies/ServiceBot/_Shared/_Design/Balance/Table_Balance_ServiceBot
+# balance rowname: ServiceBot_LOOT
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_ServiceBot_LOOT),/Game/Enemies/ServiceBot/LOOT/_Design/Character/BPChar_ServiceBot_LOOT.BPChar_ServiceBot_LOOT_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_ServiceBot_LOOT),/Game/Enemies/ServiceBot/LOOT/_Design/Character/BPChar_ServiceBot_LOOT.BPChar_ServiceBot_LOOT_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_ServiceBot_LOOT),/Game/Enemies/ServiceBot/_Shared/_Design/Balance/Table_Balance_ServiceBot.Table_Balance_ServiceBot,ServiceBot_LOOT,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_ServiceBot_LOOT),/Game/Enemies/ServiceBot/_Shared/_Design/Balance/Table_Balance_ServiceBot.Table_Balance_ServiceBot,ServiceBot_LOOT,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_ServiceBot_LOOT),/Game/Enemies/ServiceBot/_Shared/_Design/Balance/Table_Balance_ServiceBot.Table_Balance_ServiceBot,ServiceBot_LOOT,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_ServiceBot_LOOT),/Game/Enemies/ServiceBot/_Shared/_Design/Balance/Table_Balance_ServiceBot.Table_Balance_ServiceBot,ServiceBot_LOOT,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_ServiceBot_LOOT),/Game/Enemies/ServiceBot/_Shared/_Design/Balance/Table_Balance_ServiceBot.Table_Balance_ServiceBot,ServiceBot_LOOT,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_ServiceBot_LOOT),/Game/Enemies/ServiceBot/_Shared/_Design/Balance/Table_Balance_ServiceBot.Table_Balance_ServiceBot,ServiceBot_LOOT,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Captain Traunt #####
+# BPChar: BPChar_Heavy_Traunt
+# bpchar_path: /Game/Enemies/Heavy/_Unique/Traunt/_Design/Character/BPChar_Heavy_Traunt
+# balance_table: /Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique
+# balance rowname: Heavy_Traunt
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Unique/Traunt/_Design/Character/BPChar_Heavy_Traunt.BPChar_Heavy_Traunt_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Unique/Traunt/_Design/Character/BPChar_Heavy_Traunt.BPChar_Heavy_Traunt_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### General Traunt #####
+# BPChar: BPChar_HeavyDarkTraunt
+# bpchar_path: /Game/Enemies/Heavy/_Unique/DarkTraunt/_Design/Character/BPChar_HeavyDarkTraunt
+# balance_table: /Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique
+# balance rowname: Heavy_Traunt
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Unique/DarkTraunt/_Design/Character/BPChar_HeavyDarkTraunt.BPChar_HeavyDarkTraunt_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Unique/DarkTraunt/_Design/Character/BPChar_HeavyDarkTraunt.BPChar_HeavyDarkTraunt_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_HeavyDarkTraunt),/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique.Table_Balance_Heavy_Unique,Heavy_Traunt,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Gigamind #####
+# BPChar: BPChar_NogChipHolder
+# bpchar_path: /Game/Enemies/Nog/_Unique/ChipHolder/_Design/Character/BPChar_NogChipHolder
+# balance_table: /Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog_Unique
+# balance rowname: Nog_ChipHolder
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_NogChipHolder),/Game/Enemies/Nog/_Unique/ChipHolder/_Design/Character/BPChar_NogChipHolder.BPChar_NogChipHolder_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_NogChipHolder),/Game/Enemies/Nog/_Unique/ChipHolder/_Design/Character/BPChar_NogChipHolder.BPChar_NogChipHolder_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogChipHolder),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog_Unique.Table_Balance_Nog_Unique,Nog_ChipHolder,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogChipHolder),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog_Unique.Table_Balance_Nog_Unique,Nog_ChipHolder,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogChipHolder),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog_Unique.Table_Balance_Nog_Unique,Nog_ChipHolder,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogChipHolder),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog_Unique.Table_Balance_Nog_Unique,Nog_ChipHolder,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogChipHolder),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog_Unique.Table_Balance_Nog_Unique,Nog_ChipHolder,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_NogChipHolder),/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog_Unique.Table_Balance_Nog_Unique,Nog_ChipHolder,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Undertaker #####
+# BPChar: BPChar_TinkUndertaker
+# bpchar_path: /Game/Enemies/Tink/_Unique/Undertaker/_Design/Character/BPChar_TinkUndertaker
+# balance_table: /Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique
+# balance rowname: Tink_BountyPrologue
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_TinkUndertaker),/Game/Enemies/Tink/_Unique/Undertaker/_Design/Character/BPChar_TinkUndertaker.BPChar_TinkUndertaker_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_TinkUndertaker),/Game/Enemies/Tink/_Unique/Undertaker/_Design/Character/BPChar_TinkUndertaker.BPChar_TinkUndertaker_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TinkUndertaker),/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique.Table_Balance_Tink_Unique,Tink_BountyPrologue,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TinkUndertaker),/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique.Table_Balance_Tink_Unique,Tink_BountyPrologue,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TinkUndertaker),/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique.Table_Balance_Tink_Unique,Tink_BountyPrologue,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TinkUndertaker),/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique.Table_Balance_Tink_Unique,Tink_BountyPrologue,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TinkUndertaker),/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique.Table_Balance_Tink_Unique,Tink_BountyPrologue,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TinkUndertaker),/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique.Table_Balance_Tink_Unique,Tink_BountyPrologue,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Trufflemunch #####
+# BPChar: BPChar_SkagTrufflemunch
+# bpchar_path: /Game/Enemies/Skag/_Unique/Trufflemunch/_Design/Character/BPChar_SkagTrufflemunch
+# balance_table: /Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique
+# balance rowname: Trufflemunch
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Unique/Trufflemunch/_Design/Character/BPChar_SkagTrufflemunch.BPChar_SkagTrufflemunch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Unique/Trufflemunch/_Design/Character/BPChar_SkagTrufflemunch.BPChar_SkagTrufflemunch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagTrufflemunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Trufflemunch,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Buttmuch #####
+# BPChar: BPChar_SkagButtmunch
+# bpchar_path: /Game/Enemies/Skag/_Unique/Buttmunch/_Design/Character/BPChar_SkagButtmunch
+# balance_table: /Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique
+# balance rowname: Buttmunch
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Unique/Buttmunch/_Design/Character/BPChar_SkagButtmunch.BPChar_SkagButtmunch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Unique/Buttmunch/_Design/Character/BPChar_SkagButtmunch.BPChar_SkagButtmunch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_SkagButtmunch),/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique.Table_Skag_Balance_Unique,Buttmunch,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Cybil Crawly #####
+# BPChar: BPChar_VarkidHunt02_LarvaA
+# bpchar_path: /Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaA
+# balance_table: /Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique
+# balance rowname: Hunt02_Larva
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VarkidHunt02_LarvaA),/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaA.BPChar_VarkidHunt02_LarvaA_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VarkidHunt02_LarvaA),/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaA.BPChar_VarkidHunt02_LarvaA_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaA),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaA),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaA),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaA),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaA),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaA),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Edie Crawly #####
+# BPChar: BPChar_VarkidHunt02_LarvaB
+# bpchar_path: /Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaB
+# balance_table: /Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique
+# balance rowname: Hunt02_Larva
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VarkidHunt02_LarvaB),/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaB.BPChar_VarkidHunt02_LarvaB_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VarkidHunt02_LarvaB),/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaB.BPChar_VarkidHunt02_LarvaB_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaB),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaB),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaB),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaB),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaB),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaB),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Martha Crawly #####
+# BPChar: BPChar_VarkidHunt02_LarvaC
+# bpchar_path: /Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaC
+# balance_table: /Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique
+# balance rowname: Hunt02_Larva
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VarkidHunt02_LarvaC),/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaC.BPChar_VarkidHunt02_LarvaC_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VarkidHunt02_LarvaC),/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaC.BPChar_VarkidHunt02_LarvaC_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaC),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaC),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaC),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaC),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaC),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaC),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+
+
+
+##### Matty Crawly #####
+# BPChar: BPChar_VarkidHunt02_LarvaD
+# bpchar_path: //Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaD
+# balance_table: /Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique
+# balance rowname: Hunt02_Larva
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VarkidHunt02_LarvaD),//Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaD.BPChar_VarkidHunt02_LarvaD_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VarkidHunt02_LarvaD),//Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaD.BPChar_VarkidHunt02_LarvaD_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaD),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaD),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaD),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaD),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaD),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VarkidHunt02_LarvaD),/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique.Table_Varkid_Balance_Unique,Hunt02_Larva,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 

--- a/skruntskrunt/raid/raid.bl3hotfix
+++ b/skruntskrunt/raid/raid.bl3hotfix
@@ -23,15 +23,16 @@
 ### Balance help is appreciated
 
 # TODOS:
-# [ ] Captain Traunt Drops
-# [ ] Demoskagon Drops
-# [ ] Trufflemunch drops
-# [ ] Lavender Crawly seemed broken?
+# [X] Captain Traunt Drops
+# [X] Demoskagon Drops
+# [X] Urist McEnforcer
+# [X] One punch drops?
+# [X] Trufflemunch drops
+# [X] Lavender Crawly seemed broken?
 # [ ] Eista spawns loot in a meaningful way
-# [ ] One punch drops?
-# [ ] Urist McEnforcer
 # [ ] Too strong militant near one punch
-# add kratch
+# [X] add kratch
+# [ ] 
 
 # Graveward
 SparkCharacterLoadedEntry,(1,2,0,BPChar_EdenBoss),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Graveward,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
@@ -421,6 +422,28 @@ SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPools/ItemPool_D
 
 SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[51].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[51].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+
+# TruffleMuch drops
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[89].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[89].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,7
+
+# Buttmunch drops
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[88].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[88].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,7
+
+# Minemeat drops
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoBadass),/Game/PatchDLC/Raid1/GameData/Loot/ItemPools/ItemPool_Mincemeat.ItemPool_Mincemeat,Quantity,0,,(BaseValueConstant=3)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoBadass),/Game/PatchDLC/Raid1/GameData/Loot/ItemPools/ItemPool_Mincemeat.ItemPool_Mincemeat,BalancedItems.BalancedItems[1].Weight.BaseValueScale,0,,(BaseValueConstant=0,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+# Chupacabratch
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Chupacabratch,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Chupacabratch,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Chupacabratch,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Ratch_Hunt01),/Game/GameData/Loot/ItemPools/Unique/ItemPool_BloodSucker_Chupacabratch.ItemPool_BloodSucker_Chupacabratch,Quantity,0,,(BaseValueConstant=7,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
 
 
 

--- a/skruntskrunt/raid/raid.bl3hotfix
+++ b/skruntskrunt/raid/raid.bl3hotfix
@@ -78,7 +78,11 @@
 # [ ] Dumptrump loot
 
 # [ ] Buff Eista just a little
-
+# [ ] One punch drops?
+# [ ] Urist McEnforcer
+# [ ] Too strong militant near
+#     one punch
+# add kratch
 
 # Graveward
 SparkCharacterLoadedEntry,(1,2,0,BPChar_EdenBoss),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Graveward,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
@@ -98,9 +102,10 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_EdenBoss),/Game/Enemies/EdenBoss/_Shared
 SparkCharacterLoadedEntry,(1,2,0,BPChar_EdenBoss),/Game/Enemies/EdenBoss/_Shared/_Design/Balance/Table_Balance_EdenBoss_PT1.Table_Balance_EdenBoss_PT1,EdenBoss,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,40.0
 
 # Buffing Eista Invincible Health
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Hibiscus/NonPlayerCharacters/_Design/Table_Balance_HibiscusNPC.Table_Balance_HibiscusNPC,Eista_Invincible,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,150
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Hibiscus/NonPlayerCharacters/_Design/Table_Balance_HibiscusNPC.Table_Balance_HibiscusNPC,Eista_Invincible,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,150
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Hibiscus/NonPlayerCharacters/_Design/Table_Balance_HibiscusNPC.Table_Balance_HibiscusNPC,Eista_Invincible,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,150
+# Make him a bit tougher (250) (150 is quite doable)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Hibiscus/NonPlayerCharacters/_Design/Table_Balance_HibiscusNPC.Table_Balance_HibiscusNPC,Eista_Invincible,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Hibiscus/NonPlayerCharacters/_Design/Table_Balance_HibiscusNPC.Table_Balance_HibiscusNPC,Eista_Invincible,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Hibiscus/NonPlayerCharacters/_Design/Table_Balance_HibiscusNPC.Table_Balance_HibiscusNPC,Eista_Invincible,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250
 
 # Buffing Eista Invincible Damage
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Hibiscus/NonPlayerCharacters/_Design/Table_Balance_HibiscusNPC.Table_Balance_HibiscusNPC,Eista_Invincible,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,40
@@ -263,33 +268,6 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/Enemies/Loot
 SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/Enemies/Looters/Goon/_Shared/_Design/Balance/Table_Balance_GoonLooter.Table_Balance_GoonLooter,Goon_BadassLooter,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
 
 
-# 
-# # With Kill_GoatEater
-# 
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looters/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,Kill_GoatEater,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looters/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,Kill_GoatEater,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looters/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,Kill_GoatEater,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looters/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,Kill_GoatEater,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looters/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,Kill_GoatEater,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looters/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,Kill_GoatEater,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
-# 
-# # Just with Looter instead of Looters
-# 
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looter/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,LocoChantelle,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looter/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,LocoChantelle,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looter/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,LocoChantelle,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looter/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,LocoChantelle,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looter/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,LocoChantelle,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looter/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,LocoChantelle,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
-# 
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looter/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,Kill_GoatEater,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looter/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,Kill_GoatEater,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looter/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,Kill_GoatEater,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looter/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,Kill_GoatEater,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looter/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,Kill_GoatEater,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/Enemies/Looter/_Shared/Balance/Table_Balance_Looter_Uniques.Table_Balance_Looter_Uniques,Kill_GoatEater,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
-# 
-
 ############### Jack Bot ################
 
 # Jack bot! ./Apocalyptech/loot_changes/better_loot/better_loot.bl3hotfix
@@ -347,24 +325,7 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Sha
 
 
 
-
-# 
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Jackbot,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,10000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Jackbot,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,10000
-# 
-# 
-# 
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Jackbot,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,10000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Jackbot,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,10000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Jackbot,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,10000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Jackbot,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
-# 
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2.Table_Balance_JackBot_PT2,Jackbot,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,10000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2.Table_Balance_JackBot_PT2,Jackbot,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,10000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2.Table_Balance_JackBot_PT2,Jackbot,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,10000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2.Table_Balance_JackBot_PT2,Jackbot,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,10000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2.Table_Balance_JackBot_PT2,Jackbot,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,10000
-# SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2.Table_Balance_JackBot_PT2,Jackbot,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
+# Is this still working? Check it.
 
 SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Damage_JackBot.Table_Damage_JackBot,Jackbot,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,10000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Damage_JackBot.Table_Damage_JackBot,Jackbot,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,10000
@@ -374,14 +335,6 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Sha
 SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Damage_JackBot.Table_Damage_JackBot,Jackbot,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
 
 
-
-
-
-
-
-
-
-# This stuff might be crashing DLC2
 
 # Tom and Xam (10 is decreasing) (Try 30?)
 # This is Xam
@@ -409,37 +362,6 @@ SparkCharacterLoadedEntry,(1,1,0,BPChar_LostTwo_ToughBro),/Hibiscus/Enemies/Lost
 SparkCharacterLoadedEntry,(1,1,0,BPChar_LostTwo_BigBro),/Game/PatchDLC/Hibiscus/GameData/Loot/EnemyPools/ItemPoolList_Boss_Hibiscus.ItemPoolList_Boss_Hibiscus,ItemPools.ItemPools[7].NumberOfTimesToSelectFromThisPool.BaseValueScale,0,,12
 SparkCharacterLoadedEntry,(1,1,0,BPChar_LostTwo_ToughBro),/Game/PatchDLC/Hibiscus/GameData/Loot/EnemyPools/ItemPoolList_Boss_Hibiscus.ItemPoolList_Boss_Hibiscus,ItemPools.ItemPools[7].NumberOfTimesToSelectFromThisPool.BaseValueScale,0,,12
 
-###### Minosaur ########
-
-# ATTEMPT AT MINOSAUR HEALTH
-
-# /Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique
-# GerSaurian_Saurtaur
-
-# from ./Apocalyptech/loot_changes/better_loot/gen_better_loot.py
-# ("Minosaur",
-#             '/Geranium/Enemies/GerSaurian/_Unique/Saurtaur/_Design/Character',
-#             'BPChar_GerSaurianSaurtaur',
-#             0,
-#             1),
-# Minosaur
-# SparkCharacterLoadedEntry,(1,1,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/GerSaurian/_Unique/Saurtaur/_Design/Character/BPChar_GerSaurianSaurtaur.BPChar_GerSaurianSaurtaur_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-# SparkCharacterLoadedEntry,(1,1,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/GerSaurian/_Unique/Saurtaur/_Design/Character/BPChar_GerSaurianSaurtaur.BPChar_GerSaurianSaurtaur_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-
-# key GerSaurian_Saurtaur
-# /Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique
-# /Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique.Table_GerSaurian_Balance_Unique
-# GerSaurian_Saurtaur : {
-# Latest attempt at HP
-SparkCharacterLoadedEntry,(1,2,0,GerSaurian_Saurtaur),/Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique.Table_GerSaurian_Balance_Unique,GerSaurian_Saurtaur,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,20000
-SparkCharacterLoadedEntry,(1,2,0,GerSaurian_Saurtaur),/Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique.Table_GerSaurian_Balance_Unique,GerSaurian_Saurtaur,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,20000
-# Damage
-SparkCharacterLoadedEntry,(1,2,0,GerSaurian_Saurtaur),/Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique.Table_GerSaurian_Balance_Unique,GerSaurian_Saurtaur,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
-
-# From ./Apocalyptech/loot_changes/better_loot/better_loot.bl3hotfix
-# This works
-SparkCharacterLoadedEntry,(1,1,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/GerSaurian/_Unique/Saurtaur/_Design/Character/BPChar_GerSaurianSaurtaur.BPChar_GerSaurianSaurtaur_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_GerSaurianSaurtaur),/Geranium/Enemies/GerSaurian/_Unique/Saurtaur/_Design/Character/BPChar_GerSaurianSaurtaur.BPChar_GerSaurianSaurtaur_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=7,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 
 
 ###### Quartermaster ########
@@ -573,8 +495,8 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_TroyBoss),/Game/NonPlayerCharacters/Troy
 
 SparkCharacterLoadedEntry,(1,1,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/Rampager/_Design/Character/BPChar_Rampager.BPChar_Rampager_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,1,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/Rampager/_Design/Character/BPChar_Rampager.BPChar_Rampager_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1.Table_Balance_PromBoss_PT1,Rampager,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,4000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1.Table_Balance_PromBoss_PT1,Rampager,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,4000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1.Table_Balance_PromBoss_PT1,Rampager,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,2000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1.Table_Balance_PromBoss_PT1,Rampager,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,2000
 SparkCharacterLoadedEntry,(1,2,0,BPChar_Rampager),/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1.Table_Balance_PromBoss_PT1,Rampager,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
@@ -1158,19 +1080,19 @@ SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare01),/Game/Enemies/Psycho_Male/
 
 
 ##### OnePunch #####
-# BPChar: BPChar_PsychoRare03
-# bpchar_path: /Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03
+# BPChar: BPChar_OnePunch
+# bpchar_path: /Game/Enemies/Psycho_Male/_Unique/OnePunch/Design/Character/BPChar_OnePunch
 # balance_table: /Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique
 # balance rowname: OnePunch
 
-SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03.BPChar_PsychoRare03_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03.BPChar_PsychoRare03_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
-SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
-SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare03),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
+SparkCharacterLoadedEntry,(1,1,0,BPChar_OnePunch),/Game/Enemies/Psycho_Male/_Unique/OnePunch/Design/Character/BPChar_OnePunch.BPChar_OnePunch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_OnePunch),/Game/Enemies/Psycho_Male/_Unique/OnePunch/Design/Character/BPChar_OnePunch.BPChar_OnePunch_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_OnePunch),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_OnePunch),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_OnePunch),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_OnePunch),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_OnePunch),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_OnePunch),/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique.Table_Psycho_Balance_Unique,OnePunch,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
 
 
 
@@ -1252,10 +1174,6 @@ SparkCharacterLoadedEntry,(1,1,0,BPChar_KJR),/Game/Enemies/KatagawaJR/KJR/_Desig
 SparkCharacterLoadedEntry,(1,1,0,BPChar_KJR),/Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR.BPChar_KJR_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName=,ValueName=),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
 SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1.Table_Balance_KatagawaJR_PT1,KatagawaJR_Hologram,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250.0
 SparkCharacterLoadedEntry,(1,2,0,BPChar_KJR),/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1.Table_Balance_KatagawaJR_PT1,KatagawaJR_Hologram,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,30
-
-
-
-
 
 
 

--- a/skruntskrunt/raid/raid.bl3hotfix.HEAD
+++ b/skruntskrunt/raid/raid.bl3hotfix.HEAD
@@ -1,0 +1,503 @@
+###
+### Name: Raid on Bloodsun Canyon, Raid on VIP Tower, and Raid Bosses
+### Version: 1.4.0
+### Author: Abram/skruntskrunt,  Apocalyptech, EpicNNG, Grimm, alef-4, and more
+### Categories: enemy-drops, loot-system, mode-balance, enemy
+###
+### License: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+### License URL: https://creativecommons.org/licenses/by-sa/4.0/
+###
+
+### * The Raid on Bloodsun Canyon: Fight all the named enemies in
+###   Bloosun Canyon who now have the strength of invincible raid boses.
+### * The Raid on VIP Tower: Fight all the named enemies in VIP tower
+###   who now have the strength of invincible raid boses. Except
+###   Freddie. Freddie is level 2 most of the time.
+###
+###
+### This mod attempts to make bosses tougher and makes boss fights
+### non-trivial. This mod is meant for Mayhem 10/11 Level 65 End Game
+### players and meant for COOP play against bosses who are spongier,
+### stronger, and drop a lot more loot.
+###
+### Balance help is appreciated
+
+# TODOS:
+# [X] Captain Traunt Drops
+# [X] Demoskagon Drops
+# [X] Urist McEnforcer
+# [X] One punch drops?
+# [X] Trufflemunch drops
+# [X] Lavender Crawly seemed broken?
+# [X] Multiplayer demoskagon weird
+# [X] add kratch
+# [-] Buff Chupab
+# [-] Rax
+# [-] Max
+# [-] El Dragon
+# [-] Power Rangers
+# [-] Psycho Billies
+# [-] Katagawa Ball
+# [ ] Too strong militant near one punch
+# [ ] Eista spawns loot in a meaningful way
+
+
+########## This stuff is all bespoke stolen code ##################
+
+# Graveward
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EdenBoss),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Graveward,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EdenBoss),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Graveward,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EdenBoss),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Graveward,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+
+# Graveward
+SparkPatchEntry,(1,1,0,),/Game/GameData/Loot/ItemPools/Unique/ItemPool_GraveandWard_Graveward.ItemPool_GraveandWard_Graveward,BalancedItems,0,,((InventoryBalanceData=/Game/Gear/Artifacts/_Design/PartSets/Abilities/_Unique/Grave/Balance/InvBalD_Artifact_Grave.InvBalD_Artifact_Grave,ResolvedInventoryBalanceData=InventoryBalanceData'"/Game/Gear/Artifacts/_Design/PartSets/Abilities/_Unique/Grave/Balance/InvBalD_Artifact_Grave.InvBalD_Artifact_Grave"',Weight=(BaseValueConstant=0.500000)),(InventoryBalanceData=/Game/Gear/Shields/_Design/_Uniques/Ward/Balance/InvBalD_Shield_Ward.InvBalD_Shield_Ward,ResolvedInventoryBalanceData=InventoryBalanceData'"/Game/Gear/Shields/_Design/_Uniques/Ward/Balance/InvBalD_Shield_Ward.InvBalD_Shield_Ward"',Weight=(BaseValueConstant=0.500000)),(InventoryBalanceData=/Game/Gear/Weapons/AssaultRifles/Dahl/_Shared/_Design/_Unique/Earworm/Balance/Balance_DAL_AR_Earworm.Balance_DAL_AR_Earworm,ResolvedInventoryBalanceData=InventoryBalanceData'"/Game/Gear/Weapons/AssaultRifles/Dahl/_Shared/_Design/_Unique/Earworm/Balance/Balance_DAL_AR_Earworm.Balance_DAL_AR_Earworm"',Weight=(BaseValueConstant=0.500000)))
+# Was 4 (Make it 12)
+SparkPatchEntry,(1,1,0,),/Game/GameData/Loot/ItemPools/Unique/ItemPool_GraveandWard_Graveward.ItemPool_GraveandWard_Graveward,Quantity,0,,(BaseValueConstant=12)
+
+# Increase Graveward Health (165 is low?) (trying 420.0, 420 was kinda tough with amp moze) (666?)
+# 666 was tough
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EdenBoss),/Game/Enemies/EdenBoss/_Shared/_Design/Balance/Table_Balance_EdenBoss_PT1.Table_Balance_EdenBoss_PT1,EdenBoss,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,2400
+
+# Increase Graveward Damage (15 was kinda tought) (30?)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_EdenBoss),/Game/Enemies/EdenBoss/_Shared/_Design/Balance/Table_Balance_EdenBoss_PT1.Table_Balance_EdenBoss_PT1,EdenBoss,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,40.0
+
+# Buffing Eista Invincible Health
+# Make him a bit tougher (250) (150 is quite doable)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Hibiscus/NonPlayerCharacters/_Design/Table_Balance_HibiscusNPC.Table_Balance_HibiscusNPC,Eista_Invincible,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Hibiscus/NonPlayerCharacters/_Design/Table_Balance_HibiscusNPC.Table_Balance_HibiscusNPC,Eista_Invincible,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Hibiscus/NonPlayerCharacters/_Design/Table_Balance_HibiscusNPC.Table_Balance_HibiscusNPC,Eista_Invincible,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250
+
+# Buffing Eista Invincible Damage
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Hibiscus/NonPlayerCharacters/_Design/Table_Balance_HibiscusNPC.Table_Balance_HibiscusNPC,Eista_Invincible,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,40
+
+# Eista Chance to Drop
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Eista_Invincible,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Eista_Invincible,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_Eista),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Eista_Invincible,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_EistaChild_Radiation),/Game/PatchDLC/Hibiscus/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Hibiscus.Table_Legendary_SpecificLootOdds_Hibiscus,Eista_Invincible,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_EistaChild_Radiation),/Game/PatchDLC/Hibiscus/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Hibiscus.Table_Legendary_SpecificLootOdds_Hibiscus,Eista_Invincible,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Hib_EistaChild_Radiation),/Game/PatchDLC/Hibiscus/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Hibiscus.Table_Legendary_SpecificLootOdds_Hibiscus,Eista_Invincible,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+
+# Drop 12 items? for Eista
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Hibiscus/GameData/Loot/EnemyPools/ItemPool_Eista.ItemPool_Eista,Quantity,0,,(BaseValueConstant=12)
+
+# Epic's Eista Drops
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Hib_EistaChild_Radiation),/Game/PatchDLC/Hibiscus/GameData/Loot/EnemyPools/ItemPoolList_Eista.ItemPoolList_Eista,ItemPools,0,,((ItemPool=ItemPoolData'"/Game/PatchDLC/Hibiscus/GameData/Loot/Legendary/ItemPool_Hibiscus_Shields_Legendary.ItemPool_Hibiscus_Shields_Legendary"',PoolProbability=(BaseValueConstant=0.025)),(ItemPool=ItemPoolData'"/Game/Enemies/Tink/Loot/_Design/LootPools/ItemPool_LootTink_TinkLootPackOpened.ItemPool_LootTink_TinkLootPackOpened"',PoolProbability=(BaseValueConstant=0.2)),(ItemPool=ItemPoolData'"/Game/PatchDLC/Alisma/GameData/Loot/Legendary/ItemPool_Alisma_Legendary_Dedicate_Benedict.ItemPool_Alisma_Legendary_Dedicate_Benedict"',PoolProbability=(BaseValueConstant=0.2)),(ItemPool=ItemPoolData'"/Game/GameData/Loot/ItemPools/ItemPool_DiamondKeyChest.ItemPool_DiamondKeyChest"',PoolProbability=(BaseValueConstant=0.2)),(ItemPool=ItemPoolData'"/Game/PatchDLC/Hibiscus/GameData/Loot/Legendary/ItemPool_Hib_SnipeRifles_Legendary.ItemPool_Hib_SnipeRifles_Legendary"',PoolProbability=(BaseValueConstant=0.2)),(ItemPool=ItemPoolData'"/Game/GameData/Loot/ItemPools/Guns/ItemPool_Guns_VeryRare.ItemPool_Guns_VeryRare"',PoolProbability=(BaseValueConstant=0.2)),(ItemPool=ItemPoolData'"/Game/GameData/Loot/ItemPools/Shields/ItemPool_Shields_04_VeryRare.ItemPool_Shields_04_VeryRare"',PoolProbability=(BaseValueConstant=0.2)),(ItemPool=ItemPoolData'"/Game/GameData/Loot/ItemPools/GrenadeMods/ItemPool_GrenadeMods_04_VeryRare.ItemPool_GrenadeMods_04_VeryRare"',PoolProbability=(BaseValueConstant=0.2)),(ItemPool=ItemPoolData'"/Game/PatchDLC/Hibiscus/GameData/Loot/Legendary/ItemPool_Hibiscus_Shields_Legendary.ItemPool_Hibiscus_Shields_Legendary"',NumberOfTimesToSelectFromThisPool=(AttributeInitializer=BlueprintGeneratedClass'"/Game/GameData/Loot/ItemPools/Init_RandomLootCount_VeryFew.Init_RandomLootCount_VeryFew_C"')),(ItemPool=ItemPoolData'"/Game/Enemies/Tink/Loot/_Design/LootPools/ItemPool_LootTink_TinkLootPackOpened.ItemPool_LootTink_TinkLootPackOpened"',NumberOfTimesToSelectFromThisPool=(AttributeInitializer=BlueprintGeneratedClass'"/Game/GameData/Loot/ItemPools/Init_RandomLootCount_UpToFour.Init_RandomLootCount_UpToFour_C"')),(ItemPool=ItemPoolData'"/Game/PatchDLC/Alisma/GameData/Loot/Legendary/ItemPool_Alisma_Legendary_Dedicate_Benedict.ItemPool_Alisma_Legendary_Dedicate_Benedict"',NumberOfTimesToSelectFromThisPool=(AttributeInitializer=BlueprintGeneratedClass'"/Game/GameData/Loot/ItemPools/Init_RandomLootCount_UpToFour.Init_RandomLootCount_UpToFour_C"')),(ItemPool=ItemPoolData'"/Game/GameData/Loot/ItemPools/ItemPool_DiamondKeyChest.ItemPool_DiamondKeyChest"',NumberOfTimesToSelectFromThisPool=(AttributeInitializer=BlueprintGeneratedClass'"/Game/GameData/Loot/ItemPools/Init_RandomLootCount_UpToFour.Init_RandomLootCount_UpToFour_C"')),(ItemPool=ItemPoolData'"/Game/PatchDLC/Hibiscus/GameData/Loot/Legendary/ItemPool_Hib_SnipeRifles_Legendary.ItemPool_Hib_SnipeRifles_Legendary"',NumberOfTimesToSelectFromThisPool=(AttributeInitializer=BlueprintGeneratedClass'"/Game/GameData/Loot/ItemPools/Init_RandomLootCount_SomeMinOne.Init_RandomLootCount_SomeMinOne_C"')),(ItemPool=ItemPoolData'"/Game/GameData/Loot/ItemPools/Guns/ItemPool_Guns_VeryRare.ItemPool_Guns_VeryRare"',NumberOfTimesToSelectFromThisPool=(AttributeInitializer=BlueprintGeneratedClass'"/Game/GameData/Loot/ItemPools/Init_RandomLootCount_UpToSix.Init_RandomLootCount_UpToSix_C"')),(ItemPool=ItemPoolData'"/Game/GameData/Loot/ItemPools/Shields/ItemPool_Shields_04_VeryRare.ItemPool_Shields_04_VeryRare"',NumberOfTimesToSelectFromThisPool=(AttributeInitializer=BlueprintGeneratedClass'"/Game/GameData/Loot/ItemPools/Init_RandomLootCount_UpToFour.Init_RandomLootCount_UpToFour_C"')),(ItemPool=ItemPoolData'"/Game/GameData/Loot/ItemPools/GrenadeMods/ItemPool_GrenadeMods_04_VeryRare.ItemPool_GrenadeMods_04_VeryRare"',NumberOfTimesToSelectFromThisPool=(AttributeInitializer=BlueprintGeneratedClass'"/Game/GameData/Loot/ItemPools/Init_RandomLootCount_UpToFour.Init_RandomLootCount_UpToFour_C"')))
+
+# # EpicNNG's Eista Drop Pattern
+# # REPLACE EISTA DROP PATTERN WITH LOOT TINK PATTERN
+# # [ ] Untested
+# SparkCharacterLoadedEntry,(1,1,0,BPChar_Hib_EistaChild_Radiation),/Hibiscus/NonPlayerCharacters/Eista/_Design/Character/BPChar_Hib_EistaChild_Radiation.BPChar_Hib_EistaChild_Radiation_C:AIBalanceState_GEN_VARIABLE,DropLootPattern,0,,LootSpawnPatternData'/Game/Enemies/Tink/Loot/_Design/LootPools/'
+# 
+
+
+
+# Freddie!
+
+
+# Not sure this is doing anything
+# Turn Traitor Eddie into a RAID BOSS
+# Make Freddie/Eddie Drop something
+# Freddie the Traitor from Apocalyptech
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TraitorEddie),/Game/PatchDLC/Dandelion/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Dandelion.Table_Legendary_SpecificLootOdds_Dandelion,Freddie,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TraitorEddie),/Game/PatchDLC/Dandelion/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Dandelion.Table_Legendary_SpecificLootOdds_Dandelion,Freddie,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_TraitorEddie),/Game/PatchDLC/Dandelion/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Dandelion.Table_Legendary_SpecificLootOdds_Dandelion,Freddie,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+
+# # None of this seems to work anymore?
+# # check old commits?
+# # Lots of Freddie loot?
+# SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnlyTraitorEddie),/Dandelion/Enemies/TraitorEddie/_Shared/_Design/Character/BPChar_TraitorEddie.BPChar_TraitorEddie_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+# SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnlyTraitorEddie),/Dandelion/Enemies/TraitorEddie/_Shared/_Design/Character/BPChar_TraitorEddie.BPChar_TraitorEddie_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[1].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=16,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+# 
+# # /Dandelion/Enemies/TraitorEddie/_Shared/_Design/Balance/Table_Balance_TraitorEddie.Table_Balance_TraitorEddie
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnlyTraitorEddie),/Dandelion/Enemies/TraitorEddie/_Shared/_Design/Balance/Table_Balance_TraitorEddie.Table_Balance_TraitorEddie,TraitorEddie,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,666
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnlyTraitorEddie),/Dandelion/Enemies/TraitorEddie/_Shared/_Design/Balance/Table_Balance_TraitorEddie.Table_Balance_TraitorEddie,TraitorEddie,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,150
+# 
+# 
+# 
+# # # Drop 12 items? for Freddie
+# SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Dandelion/GameData/Loot/UniqueEnemyDrops/ItemPool_Freddie.ItemPool_Freddie,Quantity,0,,(BaseValueConstant=12)
+# SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Dandelion/GameData/Loot/EnemyPools/ItemPool_Freddie.ItemPool_Freddie,Quantity,0,,(BaseValueConstant=12)
+# 
+
+# New drop 20?
+# BPChar_VIPOnlyTraitorEddie
+# 
+# # SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnly_Petunia),/Dandelion/Enemies/Loader/_Unique/VIPOnly/Petunia_FreddieBot/_Design/Character/BPChar_VIPOnly_Petunia.BPChar_VIPOnly_Petunia_C:AIBalanceState_GEN_VARIABLE,BPlayThroughs.PlayThroughs[1].DropOnDeathItemPools.ItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,20
+# or try
+# # (BaseValueConstant=20,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+# # SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnly_TraitorEddie),/Dandelion/Enemies/Loader/_Unique/VIPOnly/Petunia_FreddieBot/_Design/Character/BPChar_VIPOnly_Petunia.BPChar_VIPOnly_Petunia_C:AIBalanceState_GEN_VARIABLE,BPlayThroughs.PlayThroughs[1].DropOnDeathItemPools
+# Will Freddie drop 20?
+# SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnlyTraitorEddie),/Dandelion/Enemies/TraitorEddie/_Shared/_Design/Character/BPChar_TraitorEddie.BPChar_TraitorEddie_C:AIBalanceState_GEN_VARIABLE,BPlayThroughs.PlayThroughs[1].DropOnDeathItemPools.ItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,(BaseValueConstant=20,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnlyTraitorEddie),/Dandelion/Enemies/TraitorEddie/_Shared/_Design/Character/BPChar_TraitorEddie.BPChar_TraitorEddie_C:AIBalanceState_GEN_VARIABLE,BPlayThroughs.PlayThroughs[1].DropOnDeathItemPools.ItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,20
+
+
+##### Petunia and Dandelion ######
+
+# From altef-4/3000_hyperion_slaughter
+###########
+
+####
+# Petunia Drops
+# Override the drops
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnly_Petunia),/Dandelion/Enemies/Loader/_Unique/VIPOnly/Petunia_FreddieBot/_Design/Character/BPChar_VIPOnly_Petunia.BPChar_VIPOnly_Petunia_C:AIBalanceState_GEN_VARIABLE,PlayThroughs.PlayThroughs[1].bOverrideDropOnDeathItemPools,0,,True
+# # Drop HeavyWeapons?
+# Drop Freddie Weapons?
+# SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnly_Petunia),/Dandelion/Enemies/Loader/_Unique/VIPOnly/Petunia_FreddieBot/_Design/Character/BPChar_VIPOnly_Petunia.BPChar_VIPOnly_Petunia_C:AIBalanceState_GEN_VARIABLE,PlayThroughs.PlayThroughs[1].DropOnDeathItemPools.ItemPools,0,,((ItemPool=ItemPoolData'/Game/PatchDLC/Dandelion/GameData/Loot/UniqueEnemyDrops/ItemPool_Freddie.ItemPool_Freddie',PoolProbability=(BaseValueConstant=1.0)))
+# Drop Legendaries from Dandelion
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnly_Petunia),/Dandelion/Enemies/Loader/_Unique/VIPOnly/Petunia_FreddieBot/_Design/Character/BPChar_VIPOnly_Petunia.BPChar_VIPOnly_Petunia_C:AIBalanceState_GEN_VARIABLE,PlayThroughs.PlayThroughs[1].DropOnDeathItemPools.ItemPools,0,,((ItemPool=ItemPoolData'/Game/PatchDLC/Dandelion/GameData/Loot/Legendary/ItemPool_Dandelion_Guns_Legendary.ItemPool_Dandelion_Guns_Legendary',PoolProbability=(BaseValueConstant=1.0)))
+# Drop 5?
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnly_Petunia),/Dandelion/Enemies/Loader/_Unique/VIPOnly/Petunia_FreddieBot/_Design/Character/BPChar_VIPOnly_Petunia.BPChar_VIPOnly_Petunia_C:AIBalanceState_GEN_VARIABLE,BPlayThroughs.PlayThroughs[1].DropOnDeathItemPools.ItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,5
+
+####
+# Dandelion Drops
+# Override the drops
+# Dandelion gets legendary class mods
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnly_Dandelion),/Dandelion/Enemies/Loader/_Unique/VIPOnly/Dandelion_FreddieBot/_Design/Character/BPChar_VIPOnly_Dandelion.BPChar_VIPOnly_Dandelion_C:AIBalanceState_GEN_VARIABLE,PlayThroughs.PlayThroughs[1].bOverrideDropOnDeathItemPools,0,,True
+# SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnly_Dandelion),/Dandelion/Enemies/Loader/_Unique/VIPOnly/Dandelion_FreddieBot/_Design/Character/BPChar_VIPOnly_Dandelion.BPChar_VIPOnly_Dandelion_C:AIBalanceState_GEN_VARIABLE,PlayThroughs.PlayThroughs[1].DropOnDeathItemPools.ItemPools,0,,((ItemPool=ItemPoolData'/Game/Enemies/_Shared/_Design/ItemPools/ItemPool_COVEnemyUse_HeavyWeapons.ItemPool_COVEnemyUse_HeavyWeapons',PoolProbability=(BaseValueConstant=1.0)))
+#SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnly_Dandelion),/Dandelion/Enemies/Loader/_Unique/VIPOnly/Dandelion_FreddieBot/_Design/Character/BPChar_VIPOnly_Dandelion.BPChar_VIPOnly_Dandelion_C:AIBalanceState_GEN_VARIABLE,PlayThroughs.PlayThroughs[1].DropOnDeathItemPools.ItemPools,0,,((ItemPool=ItemPoolData'/Game/PatchDLC/Dandelion/GameData/Loot/Legendary/ItemPool_Dandelion_Shields_Legendary.ItemPool_Dandelion_Shields_Legendary',PoolProbability=(BaseValueConstant=1.0)))
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnly_Dandelion),/Dandelion/Enemies/Loader/_Unique/VIPOnly/Dandelion_FreddieBot/_Design/Character/BPChar_VIPOnly_Dandelion.BPChar_VIPOnly_Dandelion_C:AIBalanceState_GEN_VARIABLE,PlayThroughs.PlayThroughs[1].DropOnDeathItemPools.ItemPools,0,,((ItemPool=ItemPoolData'/Game/PatchDLC/Dandelion/GameData/Loot/Legendary/ItemPool_ClassMods_Legendary_Dandelion.ItemPool_ClassMods_Legendary_Dandelion',PoolProbability=(BaseValueConstant=1.0)))
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_VIPOnly_Dandelion),/Dandelion/Enemies/Loader/_Unique/VIPOnly/Dandelion_FreddieBot/_Design/Character/BPChar_VIPOnly_Dandelion.BPChar_VIPOnly_Dandelion_C:AIBalanceState_GEN_VARIABLE,BPlayThroughs.PlayThroughs[1].DropOnDeathItemPools.ItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,16
+
+#######
+# Petunia HP
+# 16 and 7, try 100 and 50
+# THis one does work 1000 is too much; 500 is enough? 500 was just slow. Trying 250
+# 666 I can do pretty fast
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnly_Petunia),/Game/PatchDLC/Dandelion/Enemies/Loader/_Shared/_Design/Balance/Table_Balance_Loader_Uniques.Table_Balance_Loader_Uniques,Petunia,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnly_Petunia),/Game/PatchDLC/Dandelion/Enemies/Loader/_Shared/_Design/Balance/Table_Balance_Loader_Uniques.Table_Balance_Loader_Uniques,Petunia,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,150
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnly_Petunia),/Game/PatchDLC/Dandelion/Enemies/Loader/_Shared/_Design/Balance/Table_Balance_Loader_Uniques.Table_Balance_Loader_Uniques,Petunia,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,150
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnly_Petunia),/Game/PatchDLC/Dandelion/Enemies/Loader/_Shared/_Design/Balance/Table_Balance_Loader_Uniques.Table_Balance_Loader_Uniques,Petunia,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,150
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnly_Petunia),/Game/PatchDLC/Dandelion/Enemies/Loader/_Shared/_Design/Balance/Table_Balance_Loader_Uniques.Table_Balance_Loader_Uniques,Petunia,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,150
+# was 1.8
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnly_Petunia),/Game/PatchDLC/Dandelion/Enemies/Loader/_Shared/_Design/Balance/Table_Balance_Loader_Uniques.Table_Balance_Loader_Uniques,Petunia,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,85
+
+#######
+# Dandelion HP
+# 16 and 7, try 100 and 50
+
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnly_Dandelion),/Game/PatchDLC/Dandelion/Enemies/Loader/_Shared/_Design/Balance/Table_Balance_Loader_Uniques.Table_Balance_Loader_Uniques,Dandellion,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,800
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnly_Dandelion),/Game/PatchDLC/Dandelion/Enemies/Loader/_Shared/_Design/Balance/Table_Balance_Loader_Uniques.Table_Balance_Loader_Uniques,Dandellion,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,250
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnly_Dandelion),/Game/PatchDLC/Dandelion/Enemies/Loader/_Shared/_Design/Balance/Table_Balance_Loader_Uniques.Table_Balance_Loader_Uniques,Dandellion,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,250
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnly_Dandelion),/Game/PatchDLC/Dandelion/Enemies/Loader/_Shared/_Design/Balance/Table_Balance_Loader_Uniques.Table_Balance_Loader_Uniques,Dandellion,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,250
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnly_Dandelion),/Game/PatchDLC/Dandelion/Enemies/Loader/_Shared/_Design/Balance/Table_Balance_Loader_Uniques.Table_Balance_Loader_Uniques,Dandellion,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,250
+# was 1.8
+SparkCharacterLoadedEntry,(1,2,0,BPChar_VIPOnly_Dandelion),/Game/PatchDLC/Dandelion/Enemies/Loader/_Shared/_Design/Balance/Table_Balance_Loader_Uniques.Table_Balance_Loader_Uniques,Dandellion,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,100
+
+
+############### LOCO CHANTALE ################
+
+# Loco Chantale Drops
+# This works
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Dandelion.Table_Legendary_SpecificLootOdds_Dandelion,Kill_GoatEater,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Dandelion.Table_Legendary_SpecificLootOdds_Dandelion,Kill_GoatEater,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Game/PatchDLC/Dandelion/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Dandelion.Table_Legendary_SpecificLootOdds_Dandelion,Kill_GoatEater,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+
+
+
+
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/NonPlayerCharacters/_Design/Table_Balance_DandelionNPC.Table_Balance_DandelionNPC,LocoChantelle,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/NonPlayerCharacters/_Design/Table_Balance_DandelionNPC.Table_Balance_DandelionNPC,LocoChantelle,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/NonPlayerCharacters/_Design/Table_Balance_DandelionNPC.Table_Balance_DandelionNPC,LocoChantelle,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,1000
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/NonPlayerCharacters/_Design/Table_Balance_DandelionNPC.Table_Balance_DandelionNPC,LocoChantelle,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,1000
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/NonPlayerCharacters/_Design/Table_Balance_DandelionNPC.Table_Balance_DandelionNPC,LocoChantelle,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,1000
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/NonPlayerCharacters/_Design/Table_Balance_DandelionNPC.Table_Balance_DandelionNPC,LocoChantelle,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,40
+# 
+
+# /Dandelion/Enemies/Looters/Punk/ArmoredVIP/ might Loco?
+# /Dandelion/Enemies/Looters/_Unique/KillChallenges/BPChar_GoonBadass_Coco might be loco
+
+# See if we can set coco legendaries this way
+# _C ?
+# Drops 5 Nukems
+SparkCharacterLoadedEntry,(1,1,0,BPChar_GoonBadass_Coco),Dandelion/Enemies/Looters/_Unique/KillChallenges/BPChar_GoonBadass_Coco.BPChar_GoonBadass_Coco_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=5,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+
+
+# Goon_BadassLooter in /Dandelion/Enemies/Looters/Goon/_Shared/_Design/Balance/Table_Balance_GoonLooter
+# doesn't work
+# With LocoChantelle
+# /Dandelion/Enemies/Looters/Goon/_Shared/_Design/Balance/Table_Balance_GoonLooter.Table_Balance_GoonLooter
+# HP works but loot doesn't
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/Enemies/Looters/Goon/_Shared/_Design/Balance/Table_Balance_GoonLooter.Table_Balance_GoonLooter,Goon_BadassLooter,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,150
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/Enemies/Looters/Goon/_Shared/_Design/Balance/Table_Balance_GoonLooter.Table_Balance_GoonLooter,Goon_BadassLooter,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,150
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/Enemies/Looters/Goon/_Shared/_Design/Balance/Table_Balance_GoonLooter.Table_Balance_GoonLooter,Goon_BadassLooter,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,150
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/Enemies/Looters/Goon/_Shared/_Design/Balance/Table_Balance_GoonLooter.Table_Balance_GoonLooter,Goon_BadassLooter,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,150
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/Enemies/Looters/Goon/_Shared/_Design/Balance/Table_Balance_GoonLooter.Table_Balance_GoonLooter,Goon_BadassLooter,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,150
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GoonBadass_Coco),/Dandelion/Enemies/Looters/Goon/_Shared/_Design/Balance/Table_Balance_GoonLooter.Table_Balance_GoonLooter,Goon_BadassLooter,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
+
+
+############### Jack Bot ################
+
+# Jack bot! ./Apocalyptech/loot_changes/better_loot/better_loot.bl3hotfix
+# ./Game/PatchDLC/Dandelion/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Dandelion.uasset
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Game/PatchDLC/Dandelion/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Dandelion.Table_Legendary_SpecificLootOdds_Dandelion,Jackbot,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Game/PatchDLC/Dandelion/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Dandelion.Table_Legendary_SpecificLootOdds_Dandelion,Jackbot,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Game/PatchDLC/Dandelion/GameData/Loot/UniqueEnemyDrops/Table_Legendary_SpecificLootOdds_Dandelion.Table_Legendary_SpecificLootOdds_Dandelion,Jackbot,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+
+# Jackpot the Jack's Bot - Legendary Pool
+# SparkCharacterLoadedEntry,(1,1,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Character/BPChar_JackBot.BPChar_JackBot_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+# Was 3 now 12
+SparkCharacterLoadedEntry,(1,1,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Character/BPChar_JackBot.BPChar_JackBot_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+# /Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1
+# /Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2
+# /Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Damage_JackBot
+
+# An attempt at jackbot health!
+
+# /Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1
+# Basic?
+# Jackbot
+# Default
+
+# HP
+# 10k is too much single player
+# 2k is really hard to make a dent
+# 250 is still too easy
+# 100 is still too tough?
+# 50
+# 2000 is kinda slow
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Jackbot,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Jackbot,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Basic,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Basic,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Default,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Default,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2.Table_Balance_JackBot_PT2,Jackbot,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2.Table_Balance_JackBot_PT2,Jackbot,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2.Table_Balance_JackBot_PT2,Basic,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2.Table_Balance_JackBot_PT2,Basic,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2.Table_Balance_JackBot_PT2,Default,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT2.Table_Balance_JackBot_PT2,Default,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+
+
+# Damage
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Jackbot,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,25
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Basic,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,25
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT1,Default,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,25
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT2,Jackbot,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,25
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT2,Basic,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,25
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Balance_JackBot_PT1.Table_Balance_JackBot_PT2,Default,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,25
+
+
+
+
+# Is this still working? Check it.
+
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Damage_JackBot.Table_Damage_JackBot,Jackbot,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,10000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Damage_JackBot.Table_Damage_JackBot,Jackbot,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,10000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Damage_JackBot.Table_Damage_JackBot,Jackbot,HealthMultiplier_03_Tertiary_16_46D12ED24F464AF5278FAAA2927388E2,0,,10000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Damage_JackBot.Table_Damage_JackBot,Jackbot,HealthMultiplier_04_Quaternary_18_1B102342416A40A8DC163EA34FE48863,0,,10000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Damage_JackBot.Table_Damage_JackBot,Jackbot,HealthMultiplier_05_Quinary_20_EC017977469D43823CC907990EEF7113,0,,10000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_JackBot),/Dandelion/Enemies/JackBot/_Shared/_Design/Balance/Table_Damage_JackBot.Table_Damage_JackBot,Jackbot,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
+
+
+
+# Tom and Xam (10 is decreasing) (Try 30?)
+# This is Xam
+# Tom is tough at 300 but doable 600 is the start of sponge 1000 is a bit much
+SparkCharacterLoadedEntry,(1,2,0,BPChar_LostTwo_BigBro),/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists.Table_Balance_Cultists,Boss_LostOneBig,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,900
+SparkCharacterLoadedEntry,(1,2,0,BPChar_LostTwo_BigBro),/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists.Table_Balance_Cultists,Boss_LostOneBig,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,900
+
+# Xam 1000 is not tough for Xam (4k too easy) (8k start to sponge)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_LostTwo_ToughBro),/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists.Table_Balance_Cultists,Boss_LostOneTougho,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,14000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_LostTwo_ToughBro),/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists.Table_Balance_Cultists,Boss_LostOneTough,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,14000
+
+# Tom and Xam Damage (18.5??) (200? Don't get hit) (300?)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_LostTwo_BigBro),/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists.Table_Balance_Cultists,Boss_LostOneBig,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,300
+SparkCharacterLoadedEntry,(1,2,0,BPChar_LostTwo_ToughBro),/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists.Table_Balance_Cultists,Boss_LostOneTough,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,300
+
+# Tom Drops
+SparkCharacterLoadedEntry,(1,1,0,BPChar_LostTwo_BigBro),/Hibiscus/Enemies/LostOne/LostTwo/_Design/Character/BPChar_LostTwo_BigBro.BPChar_LostTwo_BigBro_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[1].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_LostTwo_BigBro),/Hibiscus/Enemies/LostOne/LostTwo/_Design/Character/BPChar_LostTwo_BigBro.BPChar_LostTwo_BigBro_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[1].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=7,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+# Xam Drops
+SparkCharacterLoadedEntry,(1,1,0,BPChar_LostTwo_ToughBro),/Hibiscus/Enemies/LostOne/LostTwo/_Design/Character/BPChar_LostTwo_ToughBro.BPChar_LostTwo_ToughBro_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[1].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_LostTwo_ToughBro),/Hibiscus/Enemies/LostOne/LostTwo/_Design/Character/BPChar_LostTwo_ToughBro.BPChar_LostTwo_ToughBro_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[1].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=7,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+# This feels like eridium from Xam and Tom
+SparkCharacterLoadedEntry,(1,1,0,BPChar_LostTwo_BigBro),/Game/PatchDLC/Hibiscus/GameData/Loot/EnemyPools/ItemPoolList_Boss_Hibiscus.ItemPoolList_Boss_Hibiscus,ItemPools.ItemPools[7].NumberOfTimesToSelectFromThisPool.BaseValueScale,0,,12
+SparkCharacterLoadedEntry,(1,1,0,BPChar_LostTwo_ToughBro),/Game/PatchDLC/Hibiscus/GameData/Loot/EnemyPools/ItemPoolList_Boss_Hibiscus.ItemPoolList_Boss_Hibiscus,ItemPools.ItemPools[7].NumberOfTimesToSelectFromThisPool.BaseValueScale,0,,12
+
+
+
+###### Quartermaster ########
+# BPChar_Quartermaster_Tink
+# /Geranium/Enemies/Quartermaster/_Shared/_Design/Balance/Table_Quartermaster_Balance
+#./Apocalyptech/loot_changes/better_loot/better_loot.bl3hotfix
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Quartermaster_Tink),/Game/PatchDLC/Geranium/GameData/Loot/EnemyPools/ItemPoolList_MiniBoss_Geranium.ItemPoolList_MiniBoss_Geranium,ItemPools.ItemPools[7].NumberOfTimesToSelectFromThisPool.BaseValueScale,0,,3
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Quartermaster_Tink),/Geranium/Enemies/Quartermaster/Tink/_Design/Character/BPChar_Quartermaster_Tink.BPChar_Quartermaster_Tink_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+# Go big 8
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Quartermaster_Tink),/Geranium/Enemies/Quartermaster/Tink/_Design/Character/BPChar_Quartermaster_Tink.BPChar_Quartermaster_Tink_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=8,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+# Quartermaster_Mech
+# Quartermaster_Tink
+# Quartermaster_Turret
+# /Geranium/Enemies/Quartermaster/_Shared/_Design/Balance/Table_Quartermaster_Balance
+# /Geranium/Enemies/Quartermaster/_Shared/_Design/Balance/Table_Quartermaster_Balance.Table_Quartermaster_Balance
+
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Quartermaster_Tink),/Geranium/Enemies/Quartermaster/_Shared/_Design/Balance/Table_Quartermaster_Balance.Table_Quartermaster_Balance,Quartermaster_Mech,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Quartermaster_Tink),/Geranium/Enemies/Quartermaster/_Shared/_Design/Balance/Table_Quartermaster_Balance.Table_Quartermaster_Balance,Quartermaster_Mech,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Quartermaster_Tink),/Geranium/Enemies/Quartermaster/_Shared/_Design/Balance/Table_Quartermaster_Balance.Table_Quartermaster_Balance,Quartermaster_Mech,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
+
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Quartermaster_Tink),/Geranium/Enemies/Quartermaster/_Shared/_Design/Balance/Table_Quartermaster_Balance.Table_Quartermaster_Balance,Quartermaster_Turret,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,250
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Quartermaster_Tink),/Geranium/Enemies/Quartermaster/_Shared/_Design/Balance/Table_Quartermaster_Balance.Table_Quartermaster_Balance,Quartermaster_Turret,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,100
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Quartermaster_Tink),/Geranium/Enemies/Quartermaster/_Shared/_Design/Balance/Table_Quartermaster_Balance.Table_Quartermaster_Balance,Quartermaster_Turret,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
+
+# Quartermaster has a lot of shields
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Quartermaster_Tink),/Geranium/Enemies/Quartermaster/_Shared/_Design/Balance/Table_Quartermaster_Balance.Table_Quartermaster_Balance,Quartermaster_Tink,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Quartermaster_Tink),/Geranium/Enemies/Quartermaster/_Shared/_Design/Balance/Table_Quartermaster_Balance.Table_Quartermaster_Balance,Quartermaster_Tink,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Quartermaster_Tink),/Geranium/Enemies/Quartermaster/_Shared/_Design/Balance/Table_Quartermaster_Balance.Table_Quartermaster_Balance,Quartermaster_Tink,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
+
+###### Jerrick Logan ########
+# GerPsycho_PhaserPete
+# /Geranium/Enemies/GerPsycho_Male/_Shared/_Design/Balance/Table_GerPsycho_Balance_Unique.
+# /Geranium/Enemies/GerPsycho_Male/_Shared/_Design/Balance/Table_GerPsycho_Balance_Unique.Table_GerPsycho_Balance_Unique
+
+# /Geranium/Enemies/GerPsycho_Male/_Shared/_Design/Balance/Table_GerPsycho_Balance_Unique.Table_GerPsycho_Balance_Unique
+# /Geranium/Enemies/GerPsycho_Male/_Unique/PhaserPete/_Design/Character/BPChar_GerPsychoPhaserPete
+# HP works
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GerPsychoPhaserPete),/Geranium/Enemies/GerPsycho_Male/_Shared/_Design/Balance/Table_GerPsycho_Balance_Unique.Table_GerPsycho_Balance_Unique,GerPsycho_PhaserPete,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GerPsychoPhaserPete),/Geranium/Enemies/GerPsycho_Male/_Shared/_Design/Balance/Table_GerPsycho_Balance_Unique.Table_GerPsycho_Balance_Unique,GerPsycho_PhaserPete,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,1000
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GerPsychoPhaserPete),/Geranium/Enemies/GerPsycho_Male/_Shared/_Design/Balance/Table_GerPsycho_Balance_Unique.Table_GerPsycho_Balance_Unique,GerPsycho_PhaserPete,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
+
+
+
+# Logan loot. Works
+SparkCharacterLoadedEntry,(1,1,0,BPChar_GerPsychoPhaserPete),/Geranium/Enemies/GerPsycho_Male/_Unique/PhaserPete/_Design/Character/BPChar_GerPsychoPhaserPete.BPChar_GerPsychoPhaserPete_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_GerPsychoPhaserPete),/Geranium/Enemies/GerPsycho_Male/_Unique/PhaserPete/_Design/Character/BPChar_GerPsychoPhaserPete.BPChar_GerPsychoPhaserPete_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=7,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+###### Caber Dowd ###########
+# BPChar_GerPunkLarry
+# /Geranium/Enemies/GerPunk_Female/_Unique/Larry/_Design/Character/BPChar_GerPunkLarry
+# /Geranium/Enemies/GerPunk_Female/_Shared/_Design/Balance/Table_GerPunk_Balance_Unique
+# /Geranium/Enemies/GerPunk_Female/_Shared/_Design/Balance/Table_GerPunk_Balance_Unique.Table_GerPunk_Balance_Unique
+# GerPunk_Larry
+
+# 1000 too much (2-3 player)
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GerPunkLarry),/Geranium/Enemies/GerPunk_Female/_Shared/_Design/Balance/Table_GerPunk_Balance_Unique.Table_GerPunk_Balance_Unique,GerPunk_Larry,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,500
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GerPunkLarry),/Geranium/Enemies/GerPunk_Female/_Shared/_Design/Balance/Table_GerPunk_Balance_Unique.Table_GerPunk_Balance_Unique,GerPunk_Larry,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,500
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GerPunkLarry),/Geranium/Enemies/GerPunk_Female/_Shared/_Design/Balance/Table_GerPunk_Balance_Unique.Table_GerPunk_Balance_Unique,GerPunk_Larry,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
+
+# Caber Dowd Loot. Works 
+SparkCharacterLoadedEntry,(1,1,0,BPChar_GerPunkLarry),/Geranium/Enemies/GerPunk_Female/_Unique/Larry/_Design/Character/BPChar_GerPunkLarry.BPChar_GerPunkLarry_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_GerPunkLarry),/Geranium/Enemies/GerPunk_Female/_Unique/Larry/_Design/Character/BPChar_GerPunkLarry.BPChar_GerPunkLarry_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=7,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+
+###### Dickon Goyle #########
+# BPChar_GerPunkGreg_Rakk
+# /Geranium/Enemies/GerPunk_Female/_Unique/Greg/_Design/Character/BPChar_GerPunkGreg_Rakk
+# GerPunk_Greg
+# /Geranium/Enemies/GerPunk_Female/_Shared/_Design/Balance/Table_GerPunk_Balance_Unique.Table_GerPunk_Balance_Unique
+# 1000 was a bit too much 
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GerPunkGreg_Rakk),/Geranium/Enemies/GerPunk_Female/_Shared/_Design/Balance/Table_GerPunk_Balance_Unique.Table_GerPunk_Balance_Unique,GerPunk_Greg,HealthMultiplier_01_Primary_9_07801BE24749AFC87299AD91E1B82E12,0,,750
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GerPunkGreg_Rakk),/Geranium/Enemies/GerPunk_Female/_Shared/_Design/Balance/Table_GerPunk_Balance_Unique.Table_GerPunk_Balance_Unique,GerPunk_Greg,HealthMultiplier_02_Secondary_12_9204082C4992E4200D005C8CBA622E49,0,,750
+SparkCharacterLoadedEntry,(1,2,0,BPChar_GerPunkGreg_Rakk),/Geranium/Enemies/GerPunk_Female/_Shared/_Design/Balance/Table_GerPunk_Balance_Unique.Table_GerPunk_Balance_Unique,GerPunk_Greg,DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF,0,,18.5
+
+# Works.
+SparkCharacterLoadedEntry,(1,1,0,BPChar_GerPunkGreg_Rakk),/Geranium/Enemies/GerPunk_Female/_Unique/Greg/_Design/Character/BPChar_GerPunkGreg_Rakk.BPChar_GerPunkGreg_Rakk_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_GerPunkGreg_Rakk),/Geranium/Enemies/GerPunk_Female/_Unique/Greg/_Design/Character/BPChar_GerPunkGreg_Rakk.BPChar_GerPunkGreg_Rakk_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant=7,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+
+#########
+# Ruiner (Manual)
+# The Ruiner from loot randomizer
+SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/ItemPool_RuinerBoss.ItemPool_RuinerBoss,BalancedItems.BalancedItems[0].InventoryBalanceData,0,,None
+SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/ItemPool_RuinerBoss.ItemPool_RuinerBoss,BalancedItems.BalancedItems[0].ResolvedInventoryBalanceData,0,,None
+SparkCharacterLoadedEntry,(1,1,0,BPChar_RuinerBoss),/Geranium/Enemies/Ruiner/Boss/_Design/Character/ItemPool_RuinerBoss.ItemPool_RuinerBoss,BalancedItems.BalancedItems[0].ItemPoolData,0,,ItemPoolData'"/Game/GameData/Loot/ItemPools/Guns/Pistols/ItemPool_Pistols_Legendary.ItemPool_Pistols_Legendary"'
+
+########
+# Demoskaggon (Manual)
+# Loot
+
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,DemoSkag,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,DemoSkag,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Skag_Rare01),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,DemoSkag,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPools/ItemPool_DemoSkaggon.ItemPool_DemoSkaggon,Quantity,0,,(BaseValueConstant=12)
+
+##### Captain Traunt (Manual) #####
+# BPChar: BPChar_Heavy_Traunt
+# bpchar_path: /Game/Enemies/Heavy/_Unique/Traunt/_Design/Character/BPChar_Heavy_Traunt
+# balance_table: /Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique
+# balance rowname: Heavy_Traunt
+
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,DemoSkag,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,DemoSkag,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+# SparkCharacterLoadedEntry,(1,2,0,BPChar_Heavy_Traunt),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,DemoSkag,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+# SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPools/ItemPool_CaptTraunt.ItemPool_CaptTraunt,Quantity,0,,(BaseValueConstant=12)
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[51].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[51].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,12
+
+# TruffleMuch drops
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[89].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[89].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,7
+
+# Buttmunch drops
+
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[88].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[88].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,7
+
+# Minemeat drops
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoBadass),/Game/PatchDLC/Raid1/GameData/Loot/ItemPools/ItemPool_Mincemeat.ItemPool_Mincemeat,Quantity,0,,(BaseValueConstant=3)
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoBadass),/Game/PatchDLC/Raid1/GameData/Loot/ItemPools/ItemPool_Mincemeat.ItemPool_Mincemeat,BalancedItems.BalancedItems[1].Weight.BaseValueScale,0,,(BaseValueConstant=0,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+# Chupacabratch
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Chupacabratch,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Chupacabratch,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_Ratch_Hunt01),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,Chupacabratch,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+SparkCharacterLoadedEntry,(1,1,0,BPChar_Ratch_Hunt01),/Game/GameData/Loot/ItemPools/Unique/ItemPool_BloodSucker_Chupacabratch.ItemPool_BloodSucker_Chupacabratch,Quantity,0,,(BaseValueConstant=7,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+
+# Borman Nates
+
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,BoremanNates,LegendaryDropChance_Playthrough1_48_4189D9DA42C2B912FC25209E8C353A26,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,BoremanNates,LegendaryDropChance_Playthrough2_50_11E6C8E8493E0A73AF9B35891E7CE111,0,,1
+SparkCharacterLoadedEntry,(1,2,0,BPChar_PsychoRare02),/Game/GameData/Loot/ItemPools/Table_LegendarySpecificLootOdds.Table_LegendarySpecificLootOdds,BoremanNates,LegendaryDropChance_Mayhem_49_A4643C45437ECBC97BC6629ECC66F6B6,0,,1
+
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare02),/Game/Enemies/Psycho_Male/_Unique/Rare02/_Design/Character/BPChar_PsychoRare02.BPChar_PsychoRare02_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+SparkCharacterLoadedEntry,(1,1,0,BPChar_PsychoRare02),/Game/GameData/Loot/ItemPools/Unique/ItemPool_PsychoStabber_BormanNates.ItemPool_PsychoStabber_BormanNates,Quantity,0,,(BaseValueConstant=12,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+
+
+
+# Hag of Fervor
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[48].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[48].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,2
+
+# Sera of Supremacy
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[49].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[49].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,2
+
+# Arbalest of Discipline
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[54].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[54].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,2
+
+# Tyrant of Instinct
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[60].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[60].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,2
+
+# Skag of Survival
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[62].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[62].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,2
+
+# Tink of Cunning
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[66].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[66].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,2
+
+# Indo Tyrant
+SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[58].DropOnDeathItemPools.ItemPools,0,,((ItemPool=ItemPool'"/Game/PatchDLC/Raid1/GameData/Loot/ItemPools/ItemPool_IndoTyrant.ItemPool_IndoTyrant"',PoolProbability=(BaseValueConstant=1),NumberOfTimesToSelectFromThisPool=(BaseValueConstant=3)),(ItemPool=ItemPool'"/Game/GameData/Loot/ItemPools/ItemPool_SkinsAndMisc.ItemPool_SkinsAndMisc"',PoolProbability=(BaseValueConstant=1),NumberOfTimesToSelectFromThisPool=(BaseValueConstant=1)))
+
+
+
+
+
+
+############################ Insert raid.py output here #############

--- a/skruntskrunt/raid/raid.bl3hotfix.HEAD
+++ b/skruntskrunt/raid/raid.bl3hotfix.HEAD
@@ -31,12 +31,15 @@
 # [X] Lavender Crawly seemed broken?
 # [X] Multiplayer demoskagon weird
 # [X] add kratch
-# [-] Buff Chupab
-# [-] Rax
-# [-] Max
-# [-] El Dragon
-# [-] Power Rangers
-# [-] Psycho Billies
+# [X] Beans?
+# [X] Buff Chupab
+# [X] Trials?
+# [X] Rax
+# [X] Max
+# [X] El Dragon
+# [X] Power Rangers
+# [X] Psycho Billies
+# [-] Sera of whatever isn't dropping loot?
 # [-] Katagawa Ball
 # [ ] Too strong militant near one punch
 # [ ] Eista spawns loot in a meaningful way

--- a/skruntskrunt/raid/raid.py
+++ b/skruntskrunt/raid/raid.py
@@ -133,7 +133,9 @@ more_bosses = [
     ('Edie Crawly','/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaB','/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique','Hunt02_Larva'),
     ('Martha Crawly','/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaC','/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique','Hunt02_Larva'),
     ('Matty Crawly','//Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaD','/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique','Hunt02_Larva'),
-    
+    ('Chupacabratch','/Game/Enemies/Ratch/_Unique/Hunt01/_Design/Character/BPChar_Ratch_Hunt01','/Game/Enemies/Ratch/_Shared/_Design/Balance/Table_Balance_Ratch_Unique',"Ratch_01Hunt"),
+    # this is probably a bad idea
+    ('Private Beans','/Game/Enemies/Nog/_Unique/Beans/_Design/Character/BPChar_NogBeans','/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog','Nog_Badass'),
 ]
 
 bosses = [mk_boss(*x) for x in more_bosses]

--- a/skruntskrunt/raid/raid.py
+++ b/skruntskrunt/raid/raid.py
@@ -196,6 +196,10 @@ more_bosses = [
      '/Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique','Oversphere_Katagawa'),
 ]
 
+# manual header (open the static header file)
+for line in open('raid.bl3hotfix.HEAD').readlines():
+    print(line,end='')
+
 bosses = [mk_boss(*x) for x in more_bosses]
 
 for boss in bosses:

--- a/skruntskrunt/raid/raid.py
+++ b/skruntskrunt/raid/raid.py
@@ -119,6 +119,21 @@ more_bosses = [
     ('Katagawa Jr.','/Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR','/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1','KatagawaJR_Boss'),
     # Make the holograms kinda wimpy
     ('Katagawa Jr (Hologram).','/Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR','/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1','KatagawaJR_Hologram',{'health':[DEFAULT_HEALTH/4]}),
+    ('Kratch','/Hibiscus/Enemies/_Unique/Hunt_Kratch/Character/BPChar_SlugBadass_Kratch','/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1','Slug_Badass_Hunt_Kratch'),
+    ('Fungal Gorger','/Hibiscus/Enemies/_Unique/Rare_MushroomGiant/Character/BPChar_Lost_Mush_Child','/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists','LostOne_Badass'),
+    ('AMBER LAMPS','/Game/Enemies/ServiceBot/LOOT/_Design/Character/BPChar_ServiceBot_LOOT','/Game/Enemies/ServiceBot/_Shared/_Design/Balance/Table_Balance_ServiceBot','ServiceBot_LOOT'),
+    ('Captain Traunt','/Game/Enemies/Heavy/_Unique/Traunt/_Design/Character/BPChar_Heavy_Traunt','/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique','Heavy_Traunt'),
+    # Is general traunt shared??
+    ('General Traunt','/Game/Enemies/Heavy/_Unique/DarkTraunt/_Design/Character/BPChar_HeavyDarkTraunt','/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique','Heavy_Traunt'),
+    ('Gigamind','/Game/Enemies/Nog/_Unique/ChipHolder/_Design/Character/BPChar_NogChipHolder','/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog_Unique','Nog_ChipHolder'),
+    ('Undertaker','/Game/Enemies/Tink/_Unique/Undertaker/_Design/Character/BPChar_TinkUndertaker','/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique','Tink_BountyPrologue'),
+    ('Trufflemunch','/Game/Enemies/Skag/_Unique/Trufflemunch/_Design/Character/BPChar_SkagTrufflemunch','/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique','Trufflemunch'),
+    ('Buttmuch','/Game/Enemies/Skag/_Unique/Buttmunch/_Design/Character/BPChar_SkagButtmunch','/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique','Buttmunch'),
+    ('Cybil Crawly','/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaA','/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique','Hunt02_Larva'),
+    ('Edie Crawly','/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaB','/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique','Hunt02_Larva'),
+    ('Martha Crawly','/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaC','/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique','Hunt02_Larva'),
+    ('Matty Crawly','//Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaD','/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique','Hunt02_Larva'),
+    
 ]
 
 bosses = [mk_boss(*x) for x in more_bosses]

--- a/skruntskrunt/raid/raid.py
+++ b/skruntskrunt/raid/raid.py
@@ -19,8 +19,15 @@ def buff_boss(boss): #bpchar, bpchar_path, balance_table, rowname, health,damage
     out.append(f"# bpchar_path: {boss['bpchar_path']}")
     out.append(f"# balance_table: {boss['balance_table']}")
     out.append(f"# balance rowname: {boss['rowname']}\n")
-    out.append(f"SparkCharacterLoadedEntry,(1,1,0,{boss['bpchar']}),{boss['bpchar_path']}.{boss['bpchar']}_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)")
-    out.append(f"SparkCharacterLoadedEntry,(1,1,0,{boss['bpchar']}),{boss['bpchar_path']}.{boss['bpchar']}_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant={boss['nloot']},DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)")
+    if (boss.get("raid1",None) is not None):
+        # old style Raid1 loot method
+        # stolen from Apocalyptech 'BL3 Better Loot'
+        out.append(f"SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[{boss['raid1']}].DropOnDeathItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)")
+        out.append(f"SparkPatchEntry,(1,1,0,),/Game/PatchDLC/Raid1/GameData/Loot/ItemPoolExpansions/CharacterItemPoolExpansions_Raid1.CharacterItemPoolExpansions_Raid1,CharacterExpansions.CharacterExpansions_Value[{boss['raid1']}].DropOnDeathItemPools[0].NumberOfTimesToSelectFromThisPool.BaseValueConstant,0,,{boss['nloot']}")
+    else:
+        # DLC style Loot manipulation
+        out.append(f"SparkCharacterLoadedEntry,(1,1,0,{boss['bpchar']}),{boss['bpchar_path']}.{boss['bpchar']}_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].PoolProbability,0,,(BaseValueConstant=1,DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)")
+        out.append(f"SparkCharacterLoadedEntry,(1,1,0,{boss['bpchar']}),{boss['bpchar_path']}.{boss['bpchar']}_C:AIBalanceState_GEN_VARIABLE,DropOnDeathItemPools.ItemPools[0].NumberOfTimesToSelectFromThisPool,0,,(BaseValueConstant={boss['nloot']},DataTableValue=(DataTable=None,RowName="",ValueName=""),BaseValueAttribute=None,AttributeInitializer=None,BaseValueScale=1)")
     for healthname,health in zip(HEALTHS,boss['health']):
         out.append(f"SparkCharacterLoadedEntry,(1,2,0,{boss['bpchar']}),{boss['balance_table']}.{basename(boss['balance_table'])},{boss['rowname']},{healthname},0,,{health}")
     out.append(f"SparkCharacterLoadedEntry,(1,2,0,{boss['bpchar']}),{boss['balance_table']}.{basename(boss['balance_table'])},{boss['rowname']},{DAMAGE},0,,{boss['damage']}")
@@ -38,7 +45,8 @@ def mk_boss(name, bpchar_path, balance_table, rowname,options=None):
         'balance_table':balance_table,
         'nloot':options.get('nloot',DEFAULT_NLOOT),
         'health':options.get('health',[DEFAULT_HEALTH,DEFAULT_HEALTH,DEFAULT_HEALTH,DEFAULT_HEALTH,DEFAULT_HEALTH]),
-        'damage':options.get('damage',DEFAULT_DAMAGE),    
+        'damage':options.get('damage',DEFAULT_DAMAGE),
+        'raid1':options.get('raid1',None),
     }
 
 # name, BP Path, Balance Table, Row Key in Balance Table
@@ -66,7 +74,9 @@ more_bosses = [
     ('Dumptruck',
      '/Game/Enemies/Enforcer/_Unique/BountyPrologue/_Design/Character/BPChar_Enforcer_BountyPrologue',
      '/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique',
-     'Enforcer_BountyPrologue'),
+     'Enforcer_BountyPrologue',
+     {"raid1":43},
+    ),
     ('MouthPiece',
      '/Game/Enemies/Enforcer/_Unique/SacrificeBoss/_Design/Character/BPChar_EnforcerSacrificeBoss',
      '/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique',
@@ -92,21 +102,25 @@ more_bosses = [
     ('Amach','/Hibiscus/Enemies/_Unique/Rare_ZealotPilfer/Character/BPChar_ZealotPilfer_Child_Rare',"/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists","Zealot_Pilfer_Rare"),
     ('Kritchy','/Hibiscus/Enemies/_Unique/Hunt_Kritchy/Character/BPChar_Hib_Hunt_Kritchy','/Hibiscus/Enemies/_Unique/Table_Balance_Hib_Unique','Hunt_Kritchy_Village'),
     ('Scraptrap Prime','/Game/PatchDLC/Dandelion/Enemies/Claptrap/Claptrap_Queen/_Design/Character/BPChar_ClaptrapQueen','/Game/PatchDLC/Dandelion/Enemies/Claptrap/_Shared/_Design/Balance/Table_Balance_Claptrap_PT1','Queen_PT2'), #Queen_PT2 or Queen
-    ('Tyrant of Instinct','/Game/Enemies/Saurian/_Unique/TrialBoss/_Design/Character/BPChar_Saurian_TrialBoss',"/Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique","Saurian_TrialBoss"),
+    ('Tyrant of Instinct','/Game/Enemies/Saurian/_Unique/TrialBoss/_Design/Character/BPChar_Saurian_TrialBoss',"/Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique","Saurian_TrialBoss",
+     {"raid1":60}),
     ('Tremendous Rex','/Game/Enemies/Saurian/_Unique/SlaughterBoss/_Design/Character/BPChar_Saurian_SlaughterBoss',"/Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian","Saurian_Tyrant"),
-    ('Tink of Cunning','/Game/Enemies/Tink/_Unique/TrialBoss/_Design/Character/BPChar_Tink_TrialBoss',"/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique","Tink_TrialBoss"),
-    ('Skag of Survival','/Game/Enemies/Skag/_Unique/TrialBoss/_Design/Character/BPChar_Skag_TrialBoss',"/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique","TrialBoss"),
+    ('Tink of Cunning','/Game/Enemies/Tink/_Unique/TrialBoss/_Design/Character/BPChar_Tink_TrialBoss',"/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique","Tink_TrialBoss",
+     {"raid1":66}),
+    ('Skag of Survival','/Game/Enemies/Skag/_Unique/TrialBoss/_Design/Character/BPChar_Skag_TrialBoss',"/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique","TrialBoss",
+     {"raid1":62}),
     ('Sera of Supremacy','/Game/Enemies/Guardian/_Unique/TrialBoss/_Design/Character/BPChar_Guardian_TrialBoss',"/Game/Enemies/Guardian/_Shared/_Design/Balance/Table_Balance_Guardian_Unique","Guardian_Trial_Boss"),
     ('Mr. Titan','/Game/Enemies/Goliath/_Unique/SlaughterBoss/_Design/Character/BPChar_Goliath_SlaughterBoss',"/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique",'SlaughterBoss'),
-    ('Hag of Fervor','/Game/Enemies/Goon/_Unique/TrialBoss/_Design/Character/BPChar_Goon_TrialBoss',"/Game/Enemies/Goon/_Shared/_Design/Balance/Table_Balance_Goon_Unique","Goon_BossTrial"),
-    ('Arbalest of Discipline','/Game/Enemies/Mech/_Unique/TrialBoss/_Design/Character/BPChar_Mech_TrialBoss',"/Game/Enemies/Mech/_Shared/_Design/Balance/Table_Balance_Mech","Mech_TrialBoss"), # There was also Mech_Basic
-    ('IndoTyrant','/Game/Enemies/Saurian/_Unique/Rare01/_Design/Character/BPChar_Saurian_Rare01',"/Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique","Saurian_Rare01"),
-    ('Demoskaggon','/Game/Enemies/Skag/_Unique/Rare01/_Design/Character/BPChar_Skag_Rare01','/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique',"DemoSkag"),
+    ('Hag of Fervor','/Game/Enemies/Goon/_Unique/TrialBoss/_Design/Character/BPChar_Goon_TrialBoss',"/Game/Enemies/Goon/_Shared/_Design/Balance/Table_Balance_Goon_Unique","Goon_BossTrial",{"raid1":48}),
+    ('Arbalest of Discipline','/Game/Enemies/Mech/_Unique/TrialBoss/_Design/Character/BPChar_Mech_TrialBoss',"/Game/Enemies/Mech/_Shared/_Design/Balance/Table_Balance_Mech","Mech_TrialBoss",{"raid1":54}), # There was also Mech_Basic
+    ('IndoTyrant','/Game/Enemies/Saurian/_Unique/Rare01/_Design/Character/BPChar_Saurian_Rare01',"/Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique","Saurian_Rare01",{"raid1":58}),
+    ('Demoskaggon','/Game/Enemies/Skag/_Unique/Rare01/_Design/Character/BPChar_Skag_Rare01','/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique',"DemoSkag",
+     {"health":[0.5*DEFAULT_HEALTH],"raid1":61}),
     ('Warden','/Game/Enemies/Goliath/_Unique/CageArena/_Design/Character/BPChar_Goliath_CageArena',"/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique","CageArena"),
     ('Agonizer 9000','/Game/Enemies/Agonizer_9k/_Shared/Character/BPChar_Agonizer_9k',"/Game/Enemies/Agonizer_9k/_Shared/Balance/Table_Balance_Agonizer_9k","A9K"),
     ('Wick','/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','Rare03'),
     ('Borman Nates','/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare02','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','Rare02'),
-    ('Warty','/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare01','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','Rare01'),
+    ('Warty','/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare01','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','Rare01',{"raid1":64}),
     ('OnePunch','/Game/Enemies/Psycho_Male/_Unique/OnePunch/Design/Character/BPChar_OnePunch','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','OnePunch'),
     # ('Tumorhead','/Game/Enemies/Punk_Female/_Unique/TumorHead/_Design/Character/BPChar_PunkBadass_Tumorhead',None,None), #punk_badass non-unique
     ('Judge Hightower','/Game/NonPlayerCharacters/_Promethea/AtlasSoldier/_Design/Character/BPChar_AtlasSoldier_Bounty01','/Game/NonPlayerCharacters/_Shared/_Design/Table_Balance_NPC','AtlasSoldier_Bounty'),
@@ -119,16 +133,16 @@ more_bosses = [
     ('Katagawa Jr.','/Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR','/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1','KatagawaJR_Boss'),
     # Make the holograms kinda wimpy
     ('Katagawa Jr (Hologram).','/Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR','/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1','KatagawaJR_Hologram',{'health':[DEFAULT_HEALTH/4]}),
-    ('Kratch','/Hibiscus/Enemies/_Unique/Hunt_Kratch/Character/BPChar_SlugBadass_Kratch','/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1','Slug_Badass_Hunt_Kratch'),
+    ('Kratch','/Hibiscus/Enemies/_Unique/Hunt_Kratch/Character/BPChar_SlugBadass_Kratch','/Hibiscus/Enemies/Slug/_Shared/_Design/Balance/Table_Balance_Slug_PT1','Slug_Badass_Hunt_Kratch',{"health":[DEFAULT_HEALTH/4,DEFAULT_HEALTH/4,DEFAULT_HEALTH/4,DEFAULT_HEALTH/4]}),
     ('Fungal Gorger','/Hibiscus/Enemies/_Unique/Rare_MushroomGiant/Character/BPChar_Lost_Mush_Child','/Hibiscus/Enemies/_Shared/_Design/Balance/Table_Balance_Cultists','LostOne_Badass'),
     ('AMBER LAMPS','/Game/Enemies/ServiceBot/LOOT/_Design/Character/BPChar_ServiceBot_LOOT','/Game/Enemies/ServiceBot/_Shared/_Design/Balance/Table_Balance_ServiceBot','ServiceBot_LOOT'),
-    ('Captain Traunt','/Game/Enemies/Heavy/_Unique/Traunt/_Design/Character/BPChar_Heavy_Traunt','/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique','Heavy_Traunt'),
+    ('Captain Traunt','/Game/Enemies/Heavy/_Unique/Traunt/_Design/Character/BPChar_Heavy_Traunt','/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique','Heavy_Traunt',{"raid1":51}),
     # Is general traunt shared??
-    ('General Traunt','/Game/Enemies/Heavy/_Unique/DarkTraunt/_Design/Character/BPChar_HeavyDarkTraunt','/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique','Heavy_Traunt'),
+    ('General Traunt','/Game/Enemies/Heavy/_Unique/DarkTraunt/_Design/Character/BPChar_HeavyDarkTraunt','/Game/Enemies/Heavy/_Shared/_Design/Balance/Table_Balance_Heavy_Unique','Heavy_Traunt',{"raid1":52}),
     ('Gigamind','/Game/Enemies/Nog/_Unique/ChipHolder/_Design/Character/BPChar_NogChipHolder','/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog_Unique','Nog_ChipHolder'),
     ('Undertaker','/Game/Enemies/Tink/_Unique/Undertaker/_Design/Character/BPChar_TinkUndertaker','/Game/Enemies/Tink/_Shared/_Design/Balance/Table_Balance_Tink_Unique','Tink_BountyPrologue'),
-    ('Trufflemunch','/Game/Enemies/Skag/_Unique/Trufflemunch/_Design/Character/BPChar_SkagTrufflemunch','/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique','Trufflemunch'),
-    ('Buttmuch','/Game/Enemies/Skag/_Unique/Buttmunch/_Design/Character/BPChar_SkagButtmunch','/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique','Buttmunch'),
+    ('Trufflemunch','/Game/Enemies/Skag/_Unique/Trufflemunch/_Design/Character/BPChar_SkagTrufflemunch','/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique','Trufflemunch',{"health":[DEFAULT_HEALTH/2],"raid1":89}),
+    ('Buttmunch','/Game/Enemies/Skag/_Unique/Buttmunch/_Design/Character/BPChar_SkagButtmunch','/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique','Buttmunch',{"health":[DEFAULT_HEALTH/2],"raid1":88}),
     ('Cybil Crawly','/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaA','/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique','Hunt02_Larva'),
     ('Edie Crawly','/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaB','/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique','Hunt02_Larva'),
     ('Martha Crawly','/Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaC','/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique','Hunt02_Larva'),

--- a/skruntskrunt/raid/raid.py
+++ b/skruntskrunt/raid/raid.py
@@ -12,6 +12,7 @@ DEFAULT_HEALTH=1000
 DEFAULT_NLOOT=12
 
 def buff_boss(boss): #bpchar, bpchar_path, balance_table, rowname, health,damage,nloot
+    """ Generate hotfix code for buffing a boss """
     out = []
     out.append(f"##### {boss['name']} #####")
     out.append(f"# BPChar: {boss['bpchar']}")
@@ -25,71 +26,59 @@ def buff_boss(boss): #bpchar, bpchar_path, balance_table, rowname, health,damage
     out.append(f"SparkCharacterLoadedEntry,(1,2,0,{boss['bpchar']}),{boss['balance_table']}.{basename(boss['balance_table'])},{boss['rowname']},{DAMAGE},0,,{boss['damage']}")
     return "\n".join(out)
 
-tyreen = {
-    'name':'Tyreen',
-    'bpchar':'BPChar_FinalBoss',
-    'bpchar_path':'/Game/Enemies/FinalBoss/_Shared/_Design/Character/BPChar_FinalBoss',
-    'rowname':'FinalBoss',
-    'balance_table':'/Game/Enemies/FinalBoss/_Shared/_Design/Balance/Table_Balance_FinalBoss_PT1',
-    'nloot':DEFAULT_NLOOT,
-    'health':[DEFAULT_HEALTH,DEFAULT_HEALTH],
-    'damage':DEFAULT_DAMAGE
-}
-troy = {
-    'name':'Troy',
-    'bpchar':'BPChar_TroyBoss',
-    'bpchar_path':'/Game/NonPlayerCharacters/Troy/_TheBoss/_Design/Character/BPChar_TroyBoss',
-    'rowname':'TroyBoss',
-    'balance_table':'/Game/NonPlayerCharacters/Troy/_Design/Balance/Table_Balance_TroyBoss_PT1',
-    'nloot':DEFAULT_NLOOT,
-    'health':[DEFAULT_HEALTH,DEFAULT_HEALTH],
-    'damage':DEFAULT_DAMAGE
-}
-rampager = {
-    'name':'Rampager',
-    'bpchar':'BPChar_Rampager',
-    'bpchar_path':'/Game/Enemies/PrometheaBoss/Rampager/_Design/Character/BPChar_Rampager',
-    'rowname':'Rampager',
-    'balance_table':'/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1',
-    'nloot':DEFAULT_NLOOT,
-    'health':[4*DEFAULT_HEALTH,4*DEFAULT_HEALTH],
-    'damage':DEFAULT_DAMAGE    
-}
-def mk_boss(name, bpchar_path, balance_table, rowname):
+def mk_boss(name, bpchar_path, balance_table, rowname,options=None):
+    """ factory for boss definitions (hint: shoulda been a class) """
+    if options is None:
+        options = dict()
     return {
         'name':name,
         'bpchar':basename(bpchar_path),
         'bpchar_path':bpchar_path,
         'rowname':rowname,
         'balance_table':balance_table,
-        'nloot':DEFAULT_NLOOT,
-        'health':[DEFAULT_HEALTH,DEFAULT_HEALTH,DEFAULT_HEALTH,DEFAULT_HEALTH,DEFAULT_HEALTH],
-        'damage':DEFAULT_DAMAGE    
+        'nloot':options.get('nloot',DEFAULT_NLOOT),
+        'health':options.get('health',[DEFAULT_HEALTH,DEFAULT_HEALTH,DEFAULT_HEALTH,DEFAULT_HEALTH,DEFAULT_HEALTH]),
+        'damage':options.get('damage',DEFAULT_DAMAGE),    
     }
 
-ruiner = mk_boss('Ruiner', '/Geranium/Enemies/Ruiner/Boss/_Design/Character/BPChar_RuinerBoss', '/Geranium/Enemies/Ruiner/_Shared/_Design/Balance/Table_Ruiner_Balance', 'Ruiner_Boss_PT2')
-ruiner["health"] = [x*3 for x in ruiner["health"]]
-ruiner["damage"] = 50
-minosaur = mk_boss('Minosaur','/Geranium/Enemies/GerSaurian/_Unique/Saurtaur/_Design/Character/BPChar_GerSaurianSaurtaur','/Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique','GerSaurian_Saurtaur')
-
-dumptruck = mk_boss('Dumptruck',
-                    '/Game/Enemies/Enforcer/_Unique/BountyPrologue/_Design/Character/BPChar_Enforcer_BountyPrologue',
-                    '/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique',
-                    'Enforcer_BountyPrologue')
-mouthpiece = mk_boss('MouthPiece',
-                     '/Game/Enemies/Enforcer/_Unique/SacrificeBoss/_Design/Character/BPChar_EnforcerSacrificeBoss',
-                     '/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique',
-                     'Enforcer_Mouthpiece')
-hotkarl = mk_boss('HotKarl',
-                     '/Game/Enemies/Enforcer/_Unique/Bounty01/_Design/Character/BPChar_Enforcer_Bounty01',
-                     '/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique',
-                     'Enforcer_Bounty01_HotKarl')
-shiv = mk_boss('Shiv',
-               '/Game/Enemies/Psycho_Male/_Unique/BadassPrologue/_Design/Character/BPChar_PsychoBadassPrologue',
-               "/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance",
-               "Psycho_Badass")
 # name, BP Path, Balance Table, Row Key in Balance Table
 more_bosses = [
+    ('Tyreen',
+     '/Game/Enemies/FinalBoss/_Shared/_Design/Character/BPChar_FinalBoss',
+     '/Game/Enemies/FinalBoss/_Shared/_Design/Balance/Table_Balance_FinalBoss_PT1',
+     'FinalBoss'),
+    ('Troy',
+     '/Game/NonPlayerCharacters/Troy/_TheBoss/_Design/Character/BPChar_TroyBoss',
+     '/Game/NonPlayerCharacters/Troy/_Design/Balance/Table_Balance_TroyBoss_PT1',
+     'TroyBoss'),
+
+    ('Rampager','/Game/Enemies/PrometheaBoss/Rampager/_Design/Character/BPChar_Rampager',
+     '/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1',
+     'Rampager',
+     {
+         'nloot':DEFAULT_NLOOT,
+         'health':[4*DEFAULT_HEALTH,4*DEFAULT_HEALTH],
+         'damage':DEFAULT_DAMAGE
+     }
+    ),
+    ('Ruiner', '/Geranium/Enemies/Ruiner/Boss/_Design/Character/BPChar_RuinerBoss', '/Geranium/Enemies/Ruiner/_Shared/_Design/Balance/Table_Ruiner_Balance', 'Ruiner_Boss_PT2',{"health":[DEFAULT_HEALTH*3 for health in HEALTHS],"damage":50,"nloot":20}),
+    ('Minosaur','/Geranium/Enemies/GerSaurian/_Unique/Saurtaur/_Design/Character/BPChar_GerSaurianSaurtaur','/Geranium/Enemies/GerSaurian/_Shared/_Design/Balance/Table_GerSaurian_Balance_Unique','GerSaurian_Saurtaur'),
+    ('Dumptruck',
+     '/Game/Enemies/Enforcer/_Unique/BountyPrologue/_Design/Character/BPChar_Enforcer_BountyPrologue',
+     '/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique',
+     'Enforcer_BountyPrologue'),
+    ('MouthPiece',
+     '/Game/Enemies/Enforcer/_Unique/SacrificeBoss/_Design/Character/BPChar_EnforcerSacrificeBoss',
+     '/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique',
+     'Enforcer_Mouthpiece'),
+    ('HotKarl',
+     '/Game/Enemies/Enforcer/_Unique/Bounty01/_Design/Character/BPChar_Enforcer_Bounty01',
+     '/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique',
+     'Enforcer_Bounty01_HotKarl'),
+    ('Shiv',
+     '/Game/Enemies/Psycho_Male/_Unique/BadassPrologue/_Design/Character/BPChar_PsychoBadassPrologue',
+     "/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance",
+     "Psycho_Badass"),
     ('RoadDog','/Game/Enemies/Goliath/_Unique/Rare02/_Design/Character/BPChar_Goliath_Rare02','/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique','Rare02'),
     ('Princess Tarantella II','/Game/Enemies/Spiderant/_Unique/Tarantella/_Design/Character/BPChar_SpiderantTarantella','/Game/Enemies/Spiderant/_Shared/_Design/Balance/Table_Balance_Spiderant_Unique','Spiderant_CakeRoyalty'),
     ('Waylon Hurd','/Geranium/Enemies/GerPsycho_Male/_Unique/MoleMan/_Design/Character/BPChar_GerPsychoMoleMan','/Geranium/Enemies/GerPsycho_Male/_Shared/_Design/Balance/Table_GerPsycho_Balance_Unique','GerPsycho_MoleMan'),
@@ -114,14 +103,22 @@ more_bosses = [
     ('IndoTyrant','/Game/Enemies/Saurian/_Unique/Rare01/_Design/Character/BPChar_Saurian_Rare01',"/Game/Enemies/Saurian/_Shared/_Design/Balance/Table_Balance_Saurian_Unique","Saurian_Rare01"),
     ('Demoskaggon','/Game/Enemies/Skag/_Unique/Rare01/_Design/Character/BPChar_Skag_Rare01','/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique',"DemoSkag"),
     ('Warden','/Game/Enemies/Goliath/_Unique/CageArena/_Design/Character/BPChar_Goliath_CageArena',"/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique","CageArena"),
-    ('Agonizer 9000','/Game/Enemies/Agonizer_9k/_Shared/Character/BPChar_Agonizer_9k',"/Game/Enemies/Agonizer_9k/_Shared/Balance/Table_Balance_Agonizer_9k","A9K")    
+    ('Agonizer 9000','/Game/Enemies/Agonizer_9k/_Shared/Character/BPChar_Agonizer_9k',"/Game/Enemies/Agonizer_9k/_Shared/Balance/Table_Balance_Agonizer_9k","A9K"),
+    ('Wick','/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','Rare03'),
+    ('Borman Nates','/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare02','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','Rare02'),
+    ('Warty','/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare01','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','Rare01'),
+    ('OnePunch','/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','OnePunch'),
+    # ('Tumorhead','/Game/Enemies/Punk_Female/_Unique/TumorHead/_Design/Character/BPChar_PunkBadass_Tumorhead',None,None), #punk_badass non-unique
+    ('Judge Hightower','/Game/NonPlayerCharacters/_Promethea/AtlasSoldier/_Design/Character/BPChar_AtlasSoldier_Bounty01','/Game/NonPlayerCharacters/_Shared/_Design/Table_Balance_NPC','AtlasSoldier_Bounty'),
+    ('Urist McEnforcer','/Game/Enemies/Enforcer/_Unique/Urist/_Design/Character/BPChar_EnforcerUrist','/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance','Enforcer_Shield'), # I hope this is safe
+    ('Killavolt (Kenneth)','/Game/Enemies/Enforcer/_Unique/KillaVolt/_Design/Character/BPChar_EnforcerKillaVolt','/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique','Enforcer_KillaVolt'),
+    # Katagawa Jr has holograms too, row KatagawaJR_Hologram
+    ('Katagawa Jr.','/Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR','/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1','KatagawaJR_Boss'),
+    # Make the holograms kinda wimpy
+    ('Katagawa Jr (Hologram).','/Game/Enemies/KatagawaJR/KJR/_Design/Character/BPChar_KJR','/Game/Enemies/KatagawaJR/_Shared/_Design/Balance/Table_Balance_KatagawaJR_PT1','KatagawaJR_Hologram',{'health':[DEFAULT_HEALTH/4]}),
 ]
 
-
-bosses = [tyreen, troy, rampager, ruiner, minosaur,
-          dumptruck, mouthpiece, hotkarl, shiv] 
-more_bosses = [mk_boss(*x) for x in more_bosses]
-bosses = bosses + more_bosses
+bosses = [mk_boss(*x) for x in more_bosses]
 
 for boss in bosses:
     print(buff_boss(boss))

--- a/skruntskrunt/raid/raid.py
+++ b/skruntskrunt/raid/raid.py
@@ -57,7 +57,7 @@ more_bosses = [
      'Rampager',
      {
          'nloot':DEFAULT_NLOOT,
-         'health':[4*DEFAULT_HEALTH,4*DEFAULT_HEALTH],
+         'health':[2*DEFAULT_HEALTH,2*DEFAULT_HEALTH],
          'damage':DEFAULT_DAMAGE
      }
     ),
@@ -107,9 +107,12 @@ more_bosses = [
     ('Wick','/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','Rare03'),
     ('Borman Nates','/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare02','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','Rare02'),
     ('Warty','/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare01','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','Rare01'),
-    ('OnePunch','/Game/Enemies/Psycho_Male/_Unique/Rare03/_Design/Character/BPChar_PsychoRare03','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','OnePunch'),
+    ('OnePunch','/Game/Enemies/Psycho_Male/_Unique/OnePunch/Design/Character/BPChar_OnePunch','/Game/Enemies/Psycho_Male/_Shared/_Design/Balance/Table_Psycho_Balance_Unique','OnePunch'),
     # ('Tumorhead','/Game/Enemies/Punk_Female/_Unique/TumorHead/_Design/Character/BPChar_PunkBadass_Tumorhead',None,None), #punk_badass non-unique
     ('Judge Hightower','/Game/NonPlayerCharacters/_Promethea/AtlasSoldier/_Design/Character/BPChar_AtlasSoldier_Bounty01','/Game/NonPlayerCharacters/_Shared/_Design/Table_Balance_NPC','AtlasSoldier_Bounty'),
+    # This is buggy, you need to dupe Enforcer_Shield to another entry in that balance table
+    # and then you need to set the row of BalanceTable to the Urist
+    # if you figure out how to do this you can make tumorhead unique too...
     ('Urist McEnforcer','/Game/Enemies/Enforcer/_Unique/Urist/_Design/Character/BPChar_EnforcerUrist','/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance','Enforcer_Shield'), # I hope this is safe
     ('Killavolt (Kenneth)','/Game/Enemies/Enforcer/_Unique/KillaVolt/_Design/Character/BPChar_EnforcerKillaVolt','/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique','Enforcer_KillaVolt'),
     # Katagawa Jr has holograms too, row KatagawaJR_Hologram

--- a/skruntskrunt/raid/raid.py
+++ b/skruntskrunt/raid/raid.py
@@ -10,6 +10,9 @@ DAMAGE='DamageMultiplier_LevelBased_23_3CAF34804D650A98AB8FAFAB37CB87FF'
 DEFAULT_DAMAGE=30
 DEFAULT_HEALTH=1000
 DEFAULT_NLOOT=12
+QUARTER_HEALTH=[DEFAULT_HEALTH/4 for health in HEALTHS]
+HALF_HEALTH=[DEFAULT_HEALTH/2 for health in HEALTHS]
+JUST_QUARTER_HEALTH={"health":QUARTER_HEALTH}
 
 def buff_boss(boss): #bpchar, bpchar_path, balance_table, rowname, health,damage,nloot
     """ Generate hotfix code for buffing a boss """
@@ -59,7 +62,6 @@ more_bosses = [
      '/Game/NonPlayerCharacters/Troy/_TheBoss/_Design/Character/BPChar_TroyBoss',
      '/Game/NonPlayerCharacters/Troy/_Design/Balance/Table_Balance_TroyBoss_PT1',
      'TroyBoss'),
-
     ('Rampager','/Game/Enemies/PrometheaBoss/Rampager/_Design/Character/BPChar_Rampager',
      '/Game/Enemies/PrometheaBoss/_Shared/_Design/Balance/Table_Balance_PromBoss_PT1',
      'Rampager',
@@ -150,6 +152,48 @@ more_bosses = [
     ('Chupacabratch','/Game/Enemies/Ratch/_Unique/Hunt01/_Design/Character/BPChar_Ratch_Hunt01','/Game/Enemies/Ratch/_Shared/_Design/Balance/Table_Balance_Ratch_Unique',"Ratch_01Hunt"),
     # this is probably a bad idea
     ('Private Beans','/Game/Enemies/Nog/_Unique/Beans/_Design/Character/BPChar_NogBeans','/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog','Nog_Badass'),
+    ('Rax','/Game/Enemies/Trooper/_Unique/Bounty02/Design/Character/BPChar_TrooperBounty02',
+     '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Bounty02',
+     {'raid1':91,'health':HALF_HEALTH}
+    ),
+    ('Max','/Game/Enemies/Trooper/_Unique/Bounty02/Design/Character/BPChar_TrooperBounty03',
+     '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Bounty03',
+     {'raid1':92,'health':HALF_HEALTH}
+    ),
+    ('Force Trooper Citrine','/Game/Enemies/Trooper/_Unique/Rare01b/_Design/Character/BPChar_Trooper_Rare01b',
+     '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Rare01b',
+     {'raid1':68,'health':QUARTER_HEALTH}
+    ),
+    ('Force Trooper Onyx','/Game/Enemies/Trooper/_Unique/Rare01a/_Design/Character/BPChar_Trooper_Rare01a',
+     '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Rare01a',
+     {'raid1':67,'health':QUARTER_HEALTH}
+    ),
+    ('Force Trooper Ruby','/Game/Enemies/Trooper/_Unique/Rare01a/_Design/Character/BPChar_Trooper_Rare01c',
+     '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Rare01c',
+     {'raid1':69,'health':QUARTER_HEALTH}
+    ),
+    ('Force Trooper Tourmaline','/Game/Enemies/Trooper/_Unique/Rare01a/_Design/Character/BPChar_Trooper_Rare01d',
+     '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Rare01d',
+     {'raid1':70,'health':QUARTER_HEALTH}
+    ),
+    ('Force Trooper Tourmaline','/Game/Enemies/Trooper/_Unique/Rare01a/_Design/Character/BPChar_Trooper_Rare01e',
+     '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Rare01e',
+     {'raid1':71,'health':QUARTER_HEALTH}
+    ),
+    ('El Dragón Jr.','/Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03',
+     '/Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03',
+     'Rare03'),
+    ('Killavolt (Kenneth)','/Game/Enemies/Enforcer/_Unique/KillaVolt/_Design/Character/BPChar_EnforcerKillaVolt','/Game/Enemies/Enforcer/_Shared/_Design/Balance/Table_Enforcer_Balance_Unique','Enforcer_KillaVolt'),
+    ('Pyschobillies (d)','/Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/d/BPChar_Punk_Bounty01d',
+     '/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique','Punk_Bounty02',JUST_QUARTER_HEALTH),
+    ('Pyschobillies (c)','/Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/c/BPChar_Punk_Bounty01c',
+     '/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique','Punk_Bounty02',JUST_QUARTER_HEALTH),
+    ('Pyschobillies (b)','/Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/b/BPChar_Punk_Bounty01b',
+     '/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique','Punk_Bounty02',JUST_QUARTER_HEALTH),
+    ('Pyschobillies (a)','/Game/Enemies/Punk_Female/_Unique/Bounty01/_Design/Character/a/BPChar_Punk_Bounty01a',
+     '/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique','Punk_Bounty02',JUST_QUARTER_HEALTH),
+    ('Katagawa Ball','/Game/Enemies/Oversphere/_Unique/KatagawaSphere/_Design/Character/BPChar_Oversphere_KatagawaSphere',
+     '/Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique','Oversphere_Katagawa'),
 ]
 
 bosses = [mk_boss(*x) for x in more_bosses]

--- a/skruntskrunt/raid/raid.py
+++ b/skruntskrunt/raid/raid.py
@@ -11,8 +11,10 @@ DEFAULT_DAMAGE=30
 DEFAULT_HEALTH=1000
 DEFAULT_NLOOT=12
 QUARTER_HEALTH=[DEFAULT_HEALTH/4 for health in HEALTHS]
+TWO_THIRDS_HEALTH=[2*DEFAULT_HEALTH/3 for health in HEALTHS]
 HALF_HEALTH=[DEFAULT_HEALTH/2 for health in HEALTHS]
 JUST_QUARTER_HEALTH={"health":QUARTER_HEALTH}
+JUST_TWO_THIRDS_HEALTH={"health":TWO_THIRDS_HEALTH}
 
 def buff_boss(boss): #bpchar, bpchar_path, balance_table, rowname, health,damage,nloot
     """ Generate hotfix code for buffing a boss """
@@ -111,7 +113,7 @@ more_bosses = [
      {"raid1":66}),
     ('Skag of Survival','/Game/Enemies/Skag/_Unique/TrialBoss/_Design/Character/BPChar_Skag_TrialBoss',"/Game/Enemies/Skag/_Shared/_Design/Balance/Table_Skag_Balance_Unique","TrialBoss",
      {"raid1":62}),
-    ('Sera of Supremacy','/Game/Enemies/Guardian/_Unique/TrialBoss/_Design/Character/BPChar_Guardian_TrialBoss',"/Game/Enemies/Guardian/_Shared/_Design/Balance/Table_Balance_Guardian_Unique","Guardian_Trial_Boss"),
+    ('Sera of Supremacy','/Game/Enemies/Guardian/_Unique/TrialBoss/_Design/Character/BPChar_Guardian_TrialBoss',"/Game/Enemies/Guardian/_Shared/_Design/Balance/Table_Balance_Guardian_Unique","Guardian_Trial_Boss",{"raid1":49}),
     ('Mr. Titan','/Game/Enemies/Goliath/_Unique/SlaughterBoss/_Design/Character/BPChar_Goliath_SlaughterBoss',"/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique",'SlaughterBoss'),
     ('Hag of Fervor','/Game/Enemies/Goon/_Unique/TrialBoss/_Design/Character/BPChar_Goon_TrialBoss',"/Game/Enemies/Goon/_Shared/_Design/Balance/Table_Balance_Goon_Unique","Goon_BossTrial",{"raid1":48}),
     ('Arbalest of Discipline','/Game/Enemies/Mech/_Unique/TrialBoss/_Design/Character/BPChar_Mech_TrialBoss',"/Game/Enemies/Mech/_Shared/_Design/Balance/Table_Balance_Mech","Mech_TrialBoss",{"raid1":54}), # There was also Mech_Basic
@@ -151,7 +153,7 @@ more_bosses = [
     ('Matty Crawly','//Game/Enemies/Varkid/_Unique/Hunt02/_Design/Larva/BPChar_VarkidHunt02_LarvaD','/Game/Enemies/Varkid/_Shared/_Design/Balance/Table_Varkid_Balance_Unique','Hunt02_Larva'),
     ('Chupacabratch','/Game/Enemies/Ratch/_Unique/Hunt01/_Design/Character/BPChar_Ratch_Hunt01','/Game/Enemies/Ratch/_Shared/_Design/Balance/Table_Balance_Ratch_Unique',"Ratch_01Hunt"),
     # this is probably a bad idea
-    ('Private Beans','/Game/Enemies/Nog/_Unique/Beans/_Design/Character/BPChar_NogBeans','/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog','Nog_Badass'),
+    ('Private Beans','/Game/Enemies/Nog/_Unique/Beans/_Design/Character/BPChar_NogBeans','/Game/Enemies/Nog/_Shared/_Design/Balance/Table_Balance_Nog','Nog_Badass',JUST_TWO_THIRDS_HEALTH),
     ('Rax','/Game/Enemies/Trooper/_Unique/Bounty02/Design/Character/BPChar_TrooperBounty02',
      '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Bounty02',
      {'raid1':91,'health':HALF_HEALTH}
@@ -162,23 +164,23 @@ more_bosses = [
     ),
     ('Force Trooper Citrine','/Game/Enemies/Trooper/_Unique/Rare01b/_Design/Character/BPChar_Trooper_Rare01b',
      '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Rare01b',
-     {'raid1':68,'health':QUARTER_HEALTH}
+     {'raid1':68,'health':HALF_HEALTH}
     ),
     ('Force Trooper Onyx','/Game/Enemies/Trooper/_Unique/Rare01a/_Design/Character/BPChar_Trooper_Rare01a',
      '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Rare01a',
-     {'raid1':67,'health':QUARTER_HEALTH}
+     {'raid1':67,'health':HALF_HEALTH}
     ),
     ('Force Trooper Ruby','/Game/Enemies/Trooper/_Unique/Rare01a/_Design/Character/BPChar_Trooper_Rare01c',
      '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Rare01c',
-     {'raid1':69,'health':QUARTER_HEALTH}
+     {'raid1':69,'health':HALF_HEALTH}
     ),
     ('Force Trooper Tourmaline','/Game/Enemies/Trooper/_Unique/Rare01a/_Design/Character/BPChar_Trooper_Rare01d',
      '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Rare01d',
-     {'raid1':70,'health':QUARTER_HEALTH}
+     {'raid1':70,'health':HALF_HEALTH}
     ),
     ('Force Trooper Tourmaline','/Game/Enemies/Trooper/_Unique/Rare01a/_Design/Character/BPChar_Trooper_Rare01e',
      '/Game/Enemies/Trooper/_Shared/_Design/Balance/Table_Balance_Trooper_Unique','Trooper_Rare01e',
-     {'raid1':71,'health':QUARTER_HEALTH}
+     {'raid1':71,'health':HALF_HEALTH}
     ),
     ('El Dragón Jr.','/Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03',
      '/Game/Enemies/Goliath/_Unique/Rare03/Character/BPChar_Goliath_Rare03',
@@ -194,6 +196,8 @@ more_bosses = [
      '/Game/Enemies/Punk_Female/_Shared/_Design/Balance/Table_Balance_Punk_Unique','Punk_Bounty02',JUST_QUARTER_HEALTH),
     ('Katagawa Ball','/Game/Enemies/Oversphere/_Unique/KatagawaSphere/_Design/Character/BPChar_Oversphere_KatagawaSphere',
      '/Game/Enemies/Oversphere/_Shared/_Design/Balance/Table_Balance_Oversphere_Unique','Oversphere_Katagawa'),
+    ('The Unstoppable','/Game/Enemies/Goliath/_Unique/Rare01/Character/BPChar_Goliath_Rare01',
+     '/Game/Enemies/Goliath/_Shared/_Design/Balance/Table_Balance_Goliath_Unique','Rare01'),
 ]
 
 # manual header (open the static header file)


### PR DESCRIPTION
Update the Raid on Bloodsun Canyon to support more bosses and fix the loot drop of numerous bosses. More automation as well. Less bespoke, more mechanical.