### PR TITLE
change of ReVolter Nerf with patch type

### DIFF
--- a/TheGigaMaster/ReVolter Nerf/ReVolter 150% Reduction.bl3hotfix
+++ b/TheGigaMaster/ReVolter Nerf/ReVolter 150% Reduction.bl3hotfix
@@ -14,4 +14,4 @@
 ### and completely negates using almost anything else for a large number of builds.
 ###
 
-SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),Game/PatchDLC/Ixora2/Gear/Shields/DataTable_ShieldBalance_Ixora2.DataTable_ShieldBalance_Ixora2,Re-Volter,Primary_1_56_207C26E1450330458D6C38B245C338C5,0,,0.5
+SparkLevelPatchEntry,(1,2,0,MatchAll),Game/PatchDLC/Ixora2/Gear/Shields/DataTable_ShieldBalance_Ixora2.DataTable_ShieldBalance_Ixora2,Re-Volter,Primary_1_56_207C26E1450330458D6C38B245C338C5,0,,0.5

--- a/TheGigaMaster/ReVolter Nerf/ReVolter 175% Reduction.bl3hotfix
+++ b/TheGigaMaster/ReVolter Nerf/ReVolter 175% Reduction.bl3hotfix
@@ -16,4 +16,4 @@
 ### There's 2 versions of this mod, so choose which you want.
 ###
 
-SparkEarlyLevelPatchEntry,(1,2,0,MatchAll),Game/PatchDLC/Ixora2/Gear/Shields/DataTable_ShieldBalance_Ixora2.DataTable_ShieldBalance_Ixora2,Re-Volter,Primary_1_56_207C26E1450330458D6C38B245C338C5,0,,0.25
+SparkLevelPatchEntry,(1,2,0,MatchAll),Game/PatchDLC/Ixora2/Gear/Shields/DataTable_ShieldBalance_Ixora2.DataTable_ShieldBalance_Ixora2,Re-Volter,Primary_1_56_207C26E1450330458D6C38B245C338C5,0,,0.25


### PR DESCRIPTION
still works with LevelPatchEntry instead of EarlyLevelPatchEntry after testing, so updating here as well.