### PR TITLE
Changed "Screenshot" for COV Equip Speed mod.

### DIFF
--- a/Stygian Emperor/COV/FasterEquipSpeed/StygianEmperor_COV_FasterEquipSpeed.bl3hotfix
+++ b/Stygian Emperor/COV/FasterEquipSpeed/StygianEmperor_COV_FasterEquipSpeed.bl3hotfix
@@ -6,7 +6,7 @@
 ### Contact (Discord): 𝔖𝔱𝔶𝔤𝔦𝔞𝔫 𝔈𝔪𝔭𝔢𝔯𝔬𝔯#1500 (also try Stygian Emperor#1500)
 ### Categories: gear-brand
 ###
-### Screenshot: https://i.imgur.com/KGwDLNF.png
+### Screenshot: https://i.imgur.com/W5p6II1.png
 ### Nexus: https://www.nexusmods.com/borderlands3/mods/265
 ###
 ### License: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)


### PR DESCRIPTION
Just changed the "screenshot" link to a new image, because what I first made looked more like Hyperion branding.