### PR TITLE
fixed table again, changed "linearly" to "additively"

### DIFF
--- a/Stygian Emperor/Moze/Reactive Armor/README.md
+++ b/Stygian Emperor/Moze/Reactive Armor/README.md
@@ -13,13 +13,13 @@ Reactive Armor Resistance by Rank
 Refer to the following chart for actual resistance numbers, as, due to a current limitation of hotfix-modding, the splash resistance claimed by the skill card varies slightly from the value displayed in-game (except for at rank 3):
 |Resistance| Rank 1 | Rank 2 | Rank 3 |*Rank 4*|*Rank 5*|*Rank 6*|*Rank 7*|*Rank 8*|
 | :------: | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: |
-|  Splash  | 14.3%  | 25.0%  | 33.3%  ‡*40.0%* |*45.5%* |*50.0%* |*53.8%* |*57.1%* |
-|   Fire   |  6.2%  | 11.8%  | 16.7%  ‡*21.1%* |*25.0%* |*28.6%* |*31.8%* |*34.8%* |
-| Radiation|  6.2%  | 11.8%  | 16.7%  ‡*21.1%* |*25.0%* |*28.6%* |*31.8%* |*34.8%* |
+|  Splash  | 14.3%  | 25.0%  | 33.3%  |*40.0%* |*45.5%* |*50.0%* |*53.8%* |*57.1%* |
+|   Fire   |  6.2%  | 11.8%  | 16.7%  |*21.1%* |*25.0%* |*28.6%* |*31.8%* |*34.8%* |
+| Radiation|  6.2%  | 11.8%  | 16.7%  |*21.1%* |*25.0%* |*28.6%* |*31.8%* |*34.8%* |
 
 *Ranks above 3 can only be legitimately attained through the* ***Grenadier*** *class mod.*
 
-(From my testing, it seems like the splash and other elemental resistances stack when hit by an elemental splash, though I'm not sure whether that's linearly.)
+(From my testing, it seems like the splash and other elemental resistances stack when hit by an elemental splash, though I'm not sure whether that's additively.)
 
 Changelog
 ---------

--- a/Stygian Emperor/Moze/Reactive Armor/StygianEmperor_Moze_ReactiveArmor.bl3hotfix
+++ b/Stygian Emperor/Moze/Reactive Armor/StygianEmperor_Moze_ReactiveArmor.bl3hotfix
@@ -35,7 +35,7 @@
 ### 
 ### *Ranks above 3 can only be legitimately attained through the Grenadier class mod.*
 ###
-### (From my testing, it seems like the splash and other elemental resistances stack when hit by an elemental splash, though I'm not sure whether that's linearly.)
+### (From my testing, it seems like the splash and other elemental resistances stack when hit by an elemental splash, though I'm not sure whether that's additively.)
 ###
 
 


### PR DESCRIPTION
broke the table again because I didn't save the fixed one locally; this re-fixes it. also used the more correct (?) word "additively" instead of "linearly" in the stacking mention. no changes made to the actual skill so no update to the version number.