### PR TITLE
Added Nexus link (same as Reactive Armor)

### DIFF
--- a/Stygian Emperor/Moze/Iron Bear No Self Damage/StygianEmperor_IronBearNoSelfDamage.bl3hotfix
+++ b/Stygian Emperor/Moze/Iron Bear No Self Damage/StygianEmperor_IronBearNoSelfDamage.bl3hotfix
@@ -9,6 +9,7 @@
 ### License: Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
 ### License URL: https://creativecommons.org/licenses/by-sa/4.0/
 ### 
+### Nexus: https://www.nexusmods.com/borderlands3/mods/274
 ### 
 ### DESCRIPTION
 ### Makes Iron Bear/Iron Cub deal no self-damage, so it can have even a chance to use


### PR DESCRIPTION
Uses the same Nexus page as Reactive Armor since I just added it as an optional file to that mod's page. No changes made to the actual mod.