### PR TITLE
Update Unlimited_Vehicles_Boost.bl3hotfix

### DIFF
--- a/Phenom/General/Unlimited_Vehicles_Boost.bl3hotfix
+++ b/Phenom/General/Unlimited_Vehicles_Boost.bl3hotfix
@@ -1,6 +1,6 @@
 ###
 ### Name: Unlimited Vehicles Boost
-### Version: 1.0.0
+### Version: 4.0.0
 ### Author: Phenom
 ### Categories: cheat, vehicle
 ###
@@ -9,8 +9,47 @@
 ###
 
 ###
-### The vehicles have an infinite boost.
+### TRUE INFINITE VEHICLE BOOST
+### Patches every known boost drain system
 ###
 
-SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/GameData/Vehicle/ResourcePool_VehicleBoost.ResourcePool_VehicleBoost,BaseOnIdleRegenerationRate,0,,100.0
-SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/GameData/Vehicle/ResourcePool_VehicleBoost.ResourcePool_VehicleBoost,BaseOnIdleRegenerationDelay,0,,0
+############################
+# RESOURCE POOL OVERRIDES
+############################
+
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/GameData/Vehicle/ResourcePool_VehicleBoost.ResourcePool_VehicleBoost,BaseValueConstant,0,,999999.0
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/GameData/Vehicle/ResourcePool_VehicleBoost.ResourcePool_VehicleBoost,BaseValueScale,0,,0.0
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/GameData/Vehicle/ResourcePool_VehicleBoost.ResourcePool_VehicleBoost,BaseOnIdleRegenerationRate,0,,999999.0
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/GameData/Vehicle/ResourcePool_VehicleBoost.ResourcePool_VehicleBoost,BaseOnIdleRegenerationDelay,0,,0.0
+
+############################
+# BOOST COMPONENT DRAIN
+############################
+
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/Vehicles/_Shared/_Design/VehicleSystems/VehicleBoostComponent.VehicleBoostComponent,BoostResourceCost,0,,0.0
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/Vehicles/_Shared/_Design/VehicleSystems/VehicleBoostComponent.VehicleBoostComponent,BoostResourceCostPerSecond,0,,0.0
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/Vehicles/_Shared/_Design/VehicleSystems/VehicleBoostComponent.VehicleBoostComponent,BoostResourceDrainRate,0,,0.0
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/Vehicles/_Shared/_Design/VehicleSystems/VehicleBoostComponent.VehicleBoostComponent,BoostConsumptionRate,0,,0.0
+
+############################
+# VEHICLE MOVEMENT DRAIN
+############################
+
+# Outrunner
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/Vehicles/Outrunner/_Design/VehicleMovement_Outrunner.VehicleMovement_Outrunner,BoostFuelConsumptionRate,0,,0.0
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/Vehicles/Outrunner/_Design/VehicleMovement_Outrunner.VehicleMovement_Outrunner,BoostFuelUseRate,0,,0.0
+
+# Technical
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/Vehicles/Technical/_Design/VehicleMovement_Technical.VehicleMovement_Technical,BoostFuelConsumptionRate,0,,0.0
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/Vehicles/Technical/_Design/VehicleMovement_Technical.VehicleMovement_Technical,BoostFuelUseRate,0,,0.0
+
+# Cyclone
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/Vehicles/Cyclone/_Design/VehicleMovement_Cyclone.VehicleMovement_Cyclone,BoostFuelConsumptionRate,0,,0.0
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/Vehicles/Cyclone/_Design/VehicleMovement_Cyclone.VehicleMovement_Cyclone,BoostFuelUseRate,0,,0.0
+
+############################
+# BOOST ACTIVATION COST
+############################
+
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/Vehicles/_Shared/_Design/VehicleSystems/VehicleBoostComponent.VehicleBoostComponent,BoostActivationCost,0,,0.0
+SparkLevelPatchEntry,(1,1,0,MatchAll),/Game/Vehicles/_Shared/_Design/VehicleSystems/VehicleBoostComponent.VehicleBoostComponent,BoostStartCost,0,,0.0


### PR DESCRIPTION
True unlimited boost for all vehicles.  Tested and working 3/12/2026

Vehicle boost now applies to all forms of vehicle boost and All vehicles, never drains, always stays at 100.